### PR TITLE
Add generic NeedsInput retry loop and update Claude model IDs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,7 @@ local.properties
 *.keystore
 *.jks
 gradle.properties
+
+# Local AI assistant guidance — not tracked
+CLAUDE.md
+docs/superpowers/

--- a/app/src/main/java/com/opendroid/ai/actions/ActionDispatcher.kt
+++ b/app/src/main/java/com/opendroid/ai/actions/ActionDispatcher.kt
@@ -240,7 +240,8 @@ class ActionDispatcher @Inject constructor(
                     Log.d(TAG, "║ Missing:      $firstMissing for $actionName")
                     ActionResult.NeedsInput(
                         question = "I need the $firstMissing to complete this. ${paramDef?.description ?: ""}",
-                        options = paramDef?.enumValues ?: emptyList()
+                        options = paramDef?.enumValues ?: emptyList(),
+                        metadata = mapOf("param" to firstMissing)
                     )
                 }
             }

--- a/app/src/main/java/com/opendroid/ai/actions/CommunicationActions.kt
+++ b/app/src/main/java/com/opendroid/ai/actions/CommunicationActions.kt
@@ -105,7 +105,8 @@ class CommunicationActions @Inject constructor(
                 is ContactResolution.Found -> executeCall(resolved.contact.phoneNumber, contact, context)
                 is ContactResolution.Ambiguous -> buildContactPickerResult(contact, resolved.matches, "MAKE_CALL")
                 is ContactResolution.NotFound -> ActionResult.NeedsInput(
-                    question = "I couldn't find '$contact' in your contacts. What's their number?"
+                    question = "I couldn't find '$contact' in your contacts. What's their number?",
+                    metadata = mapOf("param" to "contact")
                 )
             }
         }
@@ -126,7 +127,8 @@ class CommunicationActions @Inject constructor(
                     mapOf("message" to message)
                 )
                 is ContactResolution.NotFound -> ActionResult.NeedsInput(
-                    question = "I couldn't find '$contact'. What's their WhatsApp number?"
+                    question = "I couldn't find '$contact'. What's their WhatsApp number?",
+                    metadata = mapOf("param" to "contact")
                 )
             }
         }
@@ -153,7 +155,8 @@ class CommunicationActions @Inject constructor(
                     mapOf("message" to message)
                 )
                 is ContactResolution.NotFound -> ActionResult.NeedsInput(
-                    question = "I couldn't find '$contact'. What's their phone number?"
+                    question = "I couldn't find '$contact'. What's their phone number?",
+                    metadata = mapOf("param" to "contact")
                 )
             }
         }

--- a/app/src/main/java/com/opendroid/ai/core/agent/AgentLoop.kt
+++ b/app/src/main/java/com/opendroid/ai/core/agent/AgentLoop.kt
@@ -30,6 +30,21 @@ import java.util.UUID
 import javax.inject.Inject
 import javax.inject.Singleton
 
+private const val MAX_NEEDS_INPUT_PROMPTS = 5
+private val CONTACT_NUMBER_PROMPT_ACTIONS = setOf("MAKE_CALL", "SEND_SMS", "SEND_WHATSAPP")
+
+internal fun paramKeyForNeedsInput(needsInput: ActionResult.NeedsInput, actionName: String): String {
+    needsInput.metadata["param"]?.let { return it }
+
+    val asksForNumber = needsInput.question.contains("number", ignoreCase = true) ||
+            needsInput.question.contains("phone", ignoreCase = true)
+    return if (actionName.uppercase() in CONTACT_NUMBER_PROMPT_ACTIONS && asksForNumber) {
+        "contact"
+    } else {
+        "value"
+    }
+}
+
 sealed interface AgentState {
     object Idle : AgentState
     object Listening : AgentState
@@ -348,7 +363,31 @@ class AgentLoop @Inject constructor(
                 _agentState.value = AgentState.PlanProposed(plan)
             }
         } catch (e: Exception) {
-            // Fallback: If planning fails, process as simple query
+            fallbackOrError(userMsg, e)
+        }
+    }
+
+    /**
+     * Treat malformed plan JSON as an actionable planning failure. Other provider
+     * failures can still degrade to a normal chat response.
+     */
+    private suspend fun fallbackOrError(userMsg: ChatMessage, cause: Throwable) {
+        android.util.Log.e("AgentLoop", "Plan generation failed: ${cause.localizedMessage}", cause)
+        val isMalformedPlan = cause is kotlinx.serialization.SerializationException ||
+                cause is IllegalArgumentException
+        if (isMalformedPlan) {
+            val msg = "I understood the request but couldn't build a reliable plan for it. Mind rephrasing, or try a simpler version?"
+            val errMsg = ChatMessage(
+                id = UUID.randomUUID().toString(),
+                text = msg,
+                sender = ChatMessage.Sender.AGENT,
+                modelBadge = "System"
+            )
+            conversationRepository.insertMessage(errMsg)
+            memoryManager.storeMessage(errMsg)
+            _agentState.value = AgentState.Speaking(msg)
+            onSpeakCallback?.invoke(msg)
+        } else {
             executeSimpleQuery(userMsg)
         }
     }
@@ -409,12 +448,7 @@ class AgentLoop @Inject constructor(
             var actionResult = try {
                 var result = actionDispatcher.execute(nextStep.action, resolvedParams, context)
                 
-                // ── Handle contact disambiguation picker ──
-                if (result is ActionResult.NeedsInput && 
-                    result.metadata["type"] == "contact_picker") {
-                    result = handleContactPicker(result, nextStep.action, resolvedParams, context)
-                }
-                result
+                resolveNeedsInput(result, nextStep.action, resolvedParams, context)
             } catch (e: Exception) {
                 android.util.Log.e("AgentLoop", "Exception executing action ${nextStep.action}: ${e.localizedMessage}", e)
                 ActionResult(false, null, e.localizedMessage ?: "Unknown execution error")
@@ -557,6 +591,37 @@ class AgentLoop @Inject constructor(
         }
     }
 
+    private data class NeedsInputRetry(
+        val result: ActionResult,
+        val params: Map<String, String>
+    )
+
+    private suspend fun resolveNeedsInput(
+        initialResult: ActionResult,
+        actionName: String,
+        initialParams: Map<String, String>,
+        context: Context
+    ): ActionResult {
+        var result = initialResult
+        var params = initialParams
+
+        repeat(MAX_NEEDS_INPUT_PROMPTS) {
+            val needsInput = result as? ActionResult.NeedsInput ?: return result
+            val retry = if (needsInput.metadata["type"] == "contact_picker") {
+                handleContactPicker(needsInput, actionName, params, context)
+            } else {
+                handleNeedsInput(needsInput, actionName, params, context)
+            }
+            result = retry.result
+            params = retry.params
+        }
+
+        return ActionResult.Failure(
+            errorMsg = "Too many input prompts for $actionName",
+            fallback = "Try the command again with all required details."
+        )
+    }
+
     /**
      * Handle contact disambiguation when an action returns NeedsInput with contact_picker metadata.
      * Shows options to user, waits for selection, stores preference, re-executes action.
@@ -566,9 +631,9 @@ class AgentLoop @Inject constructor(
         actionName: String,
         originalParams: Map<String, String>,
         context: Context
-    ): ActionResult {
+    ): NeedsInputRetry {
         val meta = pickerResult.metadata
-        val matchesJson = meta["matches"] ?: return pickerResult
+        val matchesJson = meta["matches"] ?: return NeedsInputRetry(pickerResult, originalParams)
         val query = meta["query"] ?: ""
 
         // Parse the matches back from JSON
@@ -577,10 +642,10 @@ class AgentLoop @Inject constructor(
                 .decodeFromString<List<Map<String, String>>>(matchesJson)
         } catch (e: Exception) {
             android.util.Log.e("AgentLoop", "Failed to parse contact matches: ${e.message}")
-            return pickerResult
+            return NeedsInputRetry(pickerResult, originalParams)
         }
 
-        if (matches.isEmpty()) return pickerResult
+        if (matches.isEmpty()) return NeedsInputRetry(pickerResult, originalParams)
 
         // Show picker question to user via chat
         val optionsText = pickerResult.options.joinToString("\n")
@@ -639,15 +704,21 @@ class AgentLoop @Inject constructor(
                 modelBadge = "System"
             )
             conversationRepository.insertMessage(failMsg)
-            return ActionResult.Failure(
-                errorMsg = "Contact selection not understood",
-                fallback = "Please try the command again"
+            return NeedsInputRetry(
+                ActionResult.Failure(
+                    errorMsg = "Contact selection not understood",
+                    fallback = "Please try the command again"
+                ),
+                originalParams
             )
         }
 
-        val phone = selectedContact["phone"] ?: return ActionResult.Failure(
-            errorMsg = "No phone number for selected contact",
-            fallback = "Try again"
+        val phone = selectedContact["phone"] ?: return NeedsInputRetry(
+            ActionResult.Failure(
+                errorMsg = "No phone number for selected contact",
+                fallback = "Try again"
+            ),
+            originalParams
         )
         val name = selectedContact["name"] ?: "Contact"
 
@@ -673,7 +744,60 @@ class AgentLoop @Inject constructor(
             resolvedParams["message"] = meta["message"]!!
         }
 
-        return actionDispatcher.execute(actionName, resolvedParams, context)
+        return NeedsInputRetry(
+            actionDispatcher.execute(actionName, resolvedParams, context),
+            resolvedParams
+        )
+    }
+
+    /**
+     * Generic missing-parameter prompt. Shows the question, waits for the user's
+     * reply, and re-executes the action with the answer injected.
+     */
+    private suspend fun handleNeedsInput(
+        needsInput: ActionResult.NeedsInput,
+        actionName: String,
+        originalParams: Map<String, String>,
+        context: Context
+    ): NeedsInputRetry {
+        val optionsText = if (needsInput.options.isNotEmpty()) {
+            "\n\n" + needsInput.options.joinToString("\n") { "- $it" }
+        } else {
+            ""
+        }
+        val promptMsg = ChatMessage(
+            id = UUID.randomUUID().toString(),
+            text = needsInput.question + optionsText,
+            sender = ChatMessage.Sender.AGENT,
+            modelBadge = "System"
+        )
+        conversationRepository.insertMessage(promptMsg)
+        onSpeakCallback?.invoke(needsInput.question)
+
+        val answer = awaitUserResponse().trim()
+        if (answer.isEmpty()) {
+            return NeedsInputRetry(
+                ActionResult.Failure(
+                    errorMsg = "No value provided for $actionName",
+                    fallback = "Try the command again with the missing detail."
+                ),
+                originalParams
+            )
+        }
+
+        val userEcho = ChatMessage(
+            id = UUID.randomUUID().toString(),
+            text = answer,
+            sender = ChatMessage.Sender.USER
+        )
+        conversationRepository.insertMessage(userEcho)
+
+        val paramKey = paramKeyForNeedsInput(needsInput, actionName)
+        val newParams = originalParams.toMutableMap().apply { put(paramKey, answer) }
+        return NeedsInputRetry(
+            actionDispatcher.execute(actionName, newParams, context),
+            newParams
+        )
     }
 
     private suspend fun speakAndSaveSummary(plan: Plan, isSuccess: Boolean) {

--- a/app/src/main/java/com/opendroid/ai/core/llm/ModelFetcher.kt
+++ b/app/src/main/java/com/opendroid/ai/core/llm/ModelFetcher.kt
@@ -411,9 +411,9 @@ class ModelFetcher @Inject constructor(
     }
 
     private fun getAnthropicFallback() = listOf(
-        AIModel("claude-sonnet-4", "Claude Sonnet 4", "Anthropic Claude", isRecommended = true),
-        AIModel("claude-haiku-4", "Claude Haiku 4", "Anthropic Claude", isFree = true),
-        AIModel("claude-opus-4", "Claude Opus 4", "Anthropic Claude", isPremium = true)
+        AIModel("claude-sonnet-4-6", "Claude Sonnet 4.6", "Anthropic Claude", isRecommended = true),
+        AIModel("claude-haiku-4-5", "Claude Haiku 4.5", "Anthropic Claude", isFree = true),
+        AIModel("claude-opus-4-8", "Claude Opus 4.8", "Anthropic Claude", isPremium = true)
     )
 
     private fun getOpenAIFallback() = listOf(

--- a/app/src/main/java/com/opendroid/ai/core/llm/providers/ClaudeProvider.kt
+++ b/app/src/main/java/com/opendroid/ai/core/llm/providers/ClaudeProvider.kt
@@ -24,7 +24,7 @@ class ClaudeProvider @Inject constructor(
 ) : LLMProvider {
 
     override val name: String = "Anthropic Claude"
-    override val availableModels: List<String> = listOf("claude-opus-4", "claude-sonnet-4", "claude-haiku-4")
+    override val availableModels: List<String> = listOf("claude-opus-4-8", "claude-sonnet-4-6", "claude-haiku-4-5")
 
     private val gson = Gson()
     private val mediaType = "application/json; charset=utf-8".toMediaType()
@@ -37,13 +37,13 @@ class ClaudeProvider @Inject constructor(
 
         val selectedModel = if (config.activeModel.isNotBlank()) {
             when (config.activeModel) {
-                "claude-opus-4" -> "claude-opus-4-20250514"
-                "claude-sonnet-4" -> "claude-sonnet-4-20250514"
-                "claude-haiku-4" -> "claude-haiku-4-20250514"
+                "claude-opus-4-8", "claude-opus-4" -> "claude-opus-4-8"
+                "claude-sonnet-4-6", "claude-sonnet-4" -> "claude-sonnet-4-6"
+                "claude-haiku-4-5", "claude-haiku-4" -> "claude-haiku-4-5-20251001"
                 else -> config.activeModel
             }
         } else {
-            "claude-sonnet-4-20250514"
+            "claude-sonnet-4-6"
         }
 
         val messagesList = mutableListOf<Map<String, Any>>()

--- a/app/src/main/java/com/opendroid/ai/ui/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/com/opendroid/ai/ui/viewmodel/SettingsViewModel.kt
@@ -100,7 +100,7 @@ class SettingsViewModel @Inject constructor(
         val defaultModel = when (provider) {
             "Google Gemini" -> "gemini-2.0-flash"
             "OpenAI" -> "gpt-4o"
-            "Anthropic Claude" -> "claude-sonnet-4"
+            "Anthropic Claude" -> "claude-sonnet-4-6"
             "OpenRouter" -> "google/gemini-2.0-flash-exp:free"
             "Groq" -> "llama-3.3-70b-specdec"
             "Together AI" -> "meta-llama/Llama-3-70b-chat-hf"

--- a/app/src/test/java/com/opendroid/ai/actions/base/ActionResultTest.kt
+++ b/app/src/test/java/com/opendroid/ai/actions/base/ActionResultTest.kt
@@ -1,0 +1,110 @@
+package com.opendroid.ai.actions.base
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Unit tests for [ActionResult] — the sealed result contract every action
+ * returns, plus the legacy `invoke(success, data, error)` companion factory
+ * still used by call sites like AgentLoop.
+ *
+ * Pure logic, no Android dependencies.
+ */
+class ActionResultTest {
+
+    // ── Success ─────────────────────────────────────────────────────────
+
+    @Test
+    fun `success exposes the message entry as data`() {
+        val result = ActionResult.Success(mapOf("message" to "Done"))
+        assertTrue(result.success)
+        assertEquals("Done", result.data)
+        assertNull(result.error)
+    }
+
+    @Test
+    fun `success without a message key falls back to the map string`() {
+        val result = ActionResult.Success(mapOf("foo" to "bar"))
+        assertEquals(mapOf("foo" to "bar").toString(), result.data)
+    }
+
+    @Test
+    fun `empty success has null data`() {
+        val result = ActionResult.Success(emptyMap())
+        assertTrue(result.success)
+        assertNull(result.data)
+    }
+
+    // ── Failure ─────────────────────────────────────────────────────────
+
+    @Test
+    fun `failure exposes the error message`() {
+        val result = ActionResult.Failure("boom")
+        assertFalse(result.success)
+        assertNull(result.data)
+        assertEquals("boom", result.error)
+    }
+
+    @Test
+    fun `failure carries an optional fallback hint`() {
+        val result = ActionResult.Failure("boom", "try WiFi")
+        assertEquals("try WiFi", result.fallback)
+    }
+
+    // ── UnknownAction / NeedsInput ──────────────────────────────────────
+
+    @Test
+    fun `unknown action describes the attempted action in its error`() {
+        val result = ActionResult.UnknownAction("FOO", listOf("OPEN_APP"))
+        assertFalse(result.success)
+        assertEquals("Action 'FOO' is not registered in ActionDispatcher", result.error)
+    }
+
+    @Test
+    fun `needs input surfaces the question in its error`() {
+        val result = ActionResult.NeedsInput("Pick one", listOf("a", "b"))
+        assertFalse(result.success)
+        assertEquals("Needs user input: Pick one", result.error)
+    }
+
+    // ── Companion invoke factory ────────────────────────────────────────
+
+    @Test
+    fun `invoke with success wraps data into a Success`() {
+        val result = ActionResult(success = true, data = "Saved")
+        assertTrue(result is ActionResult.Success)
+        assertTrue(result.success)
+        assertEquals("Saved", result.data)
+    }
+
+    @Test
+    fun `invoke with success and null data yields empty Success`() {
+        val result = ActionResult(success = true, data = null)
+        assertTrue(result is ActionResult.Success)
+        assertNull(result.data)
+    }
+
+    @Test
+    fun `invoke with failure maps error through`() {
+        val result = ActionResult(success = false, data = null, error = "nope")
+        assertTrue(result is ActionResult.Failure)
+        assertEquals("nope", result.error)
+    }
+
+    @Test
+    fun `invoke failure with fallbackExecuted routes data into the fallback`() {
+        val result = ActionResult(false, "fallback ran", "primary failed", fallbackExecuted = true)
+        assertTrue(result is ActionResult.Failure)
+        assertEquals("primary failed", result.error)
+        assertEquals("fallback ran", (result as ActionResult.Failure).fallback)
+    }
+
+    @Test
+    fun `invoke failure with no message defaults the error text`() {
+        val result = ActionResult(success = false, data = null, error = null)
+        assertEquals("Unknown error", result.error)
+    }
+}

--- a/app/src/test/java/com/opendroid/ai/core/agent/ActionSchemaTest.kt
+++ b/app/src/test/java/com/opendroid/ai/core/agent/ActionSchemaTest.kt
@@ -1,0 +1,104 @@
+package com.opendroid.ai.core.agent
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Unit tests for [ActionSchema] — the typed action registry used to validate
+ * LLM-produced params, inject defaults, and feed the planning prompt.
+ *
+ * Pure logic, no Android dependencies.
+ */
+class ActionSchemaTest {
+
+    // ── validateParams ──────────────────────────────────────────────────
+
+    @Test
+    fun `valid when required param is present`() {
+        val (result, enriched) = ActionSchema.validateParams("OPEN_APP", mapOf("appName" to "Camera"))
+        assertTrue(result is ActionSchema.ValidationResult.Valid)
+        assertEquals("Camera", enriched["appName"])
+    }
+
+    @Test
+    fun `missing required param is reported`() {
+        val (result, _) = ActionSchema.validateParams("OPEN_APP", emptyMap())
+        assertTrue(result is ActionSchema.ValidationResult.MissingParams)
+        assertTrue((result as ActionSchema.ValidationResult.MissingParams).params.contains("appName"))
+    }
+
+    @Test
+    fun `missing optional param with default is auto-applied and stays valid`() {
+        val (result, enriched) = ActionSchema.validateParams("TOGGLE_FLASHLIGHT", emptyMap())
+        assertTrue(result is ActionSchema.ValidationResult.Valid)
+        assertEquals("toggle", enriched["state"])
+    }
+
+    @Test
+    fun `enum synonym is corrected to a canonical value`() {
+        // "enable" is a synonym for "on" in the on/off/toggle enum
+        val (result, enriched) = ActionSchema.validateParams("TOGGLE_WIFI", mapOf("state" to "enable"))
+        assertTrue(result is ActionSchema.ValidationResult.Valid)
+        assertEquals("on", enriched["state"])
+    }
+
+    @Test
+    fun `unrecognized enum value with no synonym is reported as missing`() {
+        val (result, _) = ActionSchema.validateParams("SET_RINGER_MODE", mapOf("mode" to "banana"))
+        assertTrue(result is ActionSchema.ValidationResult.MissingParams)
+        assertTrue((result as ActionSchema.ValidationResult.MissingParams).params.contains("mode"))
+    }
+
+    @Test
+    fun `unknown action yields InvalidAction`() {
+        val (result, _) = ActionSchema.validateParams("NONEXISTENT_ACTION", emptyMap())
+        assertTrue(result is ActionSchema.ValidationResult.InvalidAction)
+    }
+
+    // ── applyDefaults ───────────────────────────────────────────────────
+
+    @Test
+    fun `applyDefaults fills in missing defaulted params`() {
+        val enriched = ActionSchema.applyDefaults("TOGGLE_FLASHLIGHT", emptyMap())
+        assertEquals("toggle", enriched["state"])
+    }
+
+    @Test
+    fun `applyDefaults leaves provided params untouched`() {
+        val enriched = ActionSchema.applyDefaults("OPEN_APP", mapOf("appName" to "Spotify"))
+        assertEquals("Spotify", enriched["appName"])
+    }
+
+    // ── Lookup utilities ────────────────────────────────────────────────
+
+    @Test
+    fun `getAction finds known actions and misses unknown ones`() {
+        assertNotNull(ActionSchema.getAction("OPEN_APP"))
+        assertNull(ActionSchema.getAction("NOPE"))
+    }
+
+    @Test
+    fun `isValid reflects schema membership`() {
+        assertTrue(ActionSchema.isValid("CHAT"))
+        assertFalse(ActionSchema.isValid("NOPE"))
+    }
+
+    @Test
+    fun `getAllActionNames is non-empty and sorted`() {
+        val names = ActionSchema.getAllActionNames()
+        assertTrue(names.isNotEmpty())
+        assertTrue(names.contains("OPEN_APP"))
+        assertEquals(names.sorted(), names)
+    }
+
+    @Test
+    fun `getSimpleActions separates simple from compound actions`() {
+        val simple = ActionSchema.getSimpleActions()
+        assertTrue(simple.contains("TOGGLE_FLASHLIGHT")) // isSimple = true
+        assertFalse(simple.contains("SEND_EMAIL"))       // isSimple = false
+    }
+}

--- a/app/src/test/java/com/opendroid/ai/core/agent/AliasResolverTest.kt
+++ b/app/src/test/java/com/opendroid/ai/core/agent/AliasResolverTest.kt
@@ -1,0 +1,134 @@
+package com.opendroid.ai.core.agent
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Unit tests for [AliasResolver] — the LLM-bypass fast path that maps common
+ * natural-language phrases directly to action hints.
+ *
+ * Pure logic, no Android dependencies.
+ */
+class AliasResolverTest {
+
+    // ── Exact alias matching ────────────────────────────────────────────
+
+    @Test
+    fun `bare flash resolves to flashlight toggle`() {
+        val hint = AliasResolver.resolve("flash")
+        assertNotNull(hint)
+        assertEquals("TOGGLE_FLASHLIGHT", hint!!.action)
+        assertEquals("toggle", hint.baseParams["state"])
+    }
+
+    @Test
+    fun `explicit on and off variants carry the right state`() {
+        assertEquals("on", AliasResolver.resolve("turn on flashlight")?.baseParams?.get("state"))
+        assertEquals("off", AliasResolver.resolve("torch off")?.baseParams?.get("state"))
+    }
+
+    @Test
+    fun `mute maps to ring volume zero`() {
+        val hint = AliasResolver.resolve("mute")
+        assertNotNull(hint)
+        assertEquals("SET_VOLUME", hint!!.action)
+        assertEquals("ring", hint.baseParams["type"])
+        assertEquals("0", hint.baseParams["level"])
+    }
+
+    // ── cleanInput: stop-word / filler stripping ────────────────────────
+
+    @Test
+    fun `filler words are stripped before exact matching`() {
+        // "the" and "please" are removed, leaving the exact alias "turn on flashlight"
+        val hint = AliasResolver.resolve("turn on the flashlight please")
+        assertNotNull(hint)
+        assertEquals("TOGGLE_FLASHLIGHT", hint!!.action)
+        assertEquals("on", hint.baseParams["state"])
+    }
+
+    // ── Dynamic brightness extraction ───────────────────────────────────
+
+    @Test
+    fun `brightness with explicit percent extracts the number`() {
+        val hint = AliasResolver.resolve("set brightness to 30%")
+        assertNotNull(hint)
+        assertEquals("SET_BRIGHTNESS", hint!!.action)
+        assertEquals("30", hint.baseParams["level"])
+    }
+
+    @Test
+    fun `bare brightness defaults to 50`() {
+        val hint = AliasResolver.resolve("brightness")
+        assertNotNull(hint)
+        assertEquals("SET_BRIGHTNESS", hint!!.action)
+        assertEquals("50", hint.baseParams["level"])
+    }
+
+    @Test
+    fun `brightness above 100 is clamped`() {
+        val hint = AliasResolver.resolve("set brightness to 150")
+        assertNotNull(hint)
+        assertEquals("100", hint!!.baseParams["level"])
+    }
+
+    // ── Dynamic volume extraction ───────────────────────────────────────
+
+    @Test
+    fun `volume with number resolves to media volume`() {
+        val hint = AliasResolver.resolve("volume 70")
+        assertNotNull(hint)
+        assertEquals("SET_VOLUME", hint!!.action)
+        assertEquals("media", hint.baseParams["type"])
+        assertEquals("70", hint.baseParams["level"])
+    }
+
+    // ── Compound-intent guard ───────────────────────────────────────────
+
+    @Test
+    fun `compound intent commands fall through to the LLM (null)`() {
+        // Contains "send"/"message" — must NOT match the "open whatsapp" alias,
+        // so the LLM can build SEND_WHATSAPP with contact + message params.
+        assertNull(AliasResolver.resolve("open whatsapp and send message to dad"))
+    }
+
+    // ── Longest partial match for simple, single-intent inputs ──────────
+
+    @Test
+    fun `single-intent phrase resolves via partial match`() {
+        val hint = AliasResolver.resolve("can you take a screenshot for me")
+        assertNotNull(hint)
+        assertEquals("TAKE_SCREENSHOT", hint!!.action)
+    }
+
+    @Test
+    fun `unknown phrase returns null`() {
+        assertNull(AliasResolver.resolve("what is the meaning of life"))
+    }
+
+    // ── Alarm helpers ───────────────────────────────────────────────────
+
+    @Test
+    fun `isAlarmRequest detects alarm phrases`() {
+        assertTrue(AliasResolver.isAlarmRequest("wake me up at 7"))
+        assertTrue(AliasResolver.isAlarmRequest("set an alarm for 6:30"))
+    }
+
+    @Test
+    fun `isAlarmRequest is false for non-alarm input`() {
+        org.junit.Assert.assertFalse(AliasResolver.isAlarmRequest("what time is it"))
+    }
+
+    @Test
+    fun `extractAlarmTime isolates the time portion`() {
+        assertEquals("7", AliasResolver.extractAlarmTime("wake me up at 7"))
+    }
+
+    @Test
+    fun `extractAlarmTime returns null when no time remains`() {
+        assertNull(AliasResolver.extractAlarmTime("set alarm"))
+    }
+}

--- a/app/src/test/java/com/opendroid/ai/core/agent/NeedsInputParamKeyTest.kt
+++ b/app/src/test/java/com/opendroid/ai/core/agent/NeedsInputParamKeyTest.kt
@@ -1,0 +1,36 @@
+package com.opendroid.ai.core.agent
+
+import com.opendroid.ai.actions.base.ActionResult
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class NeedsInputParamKeyTest {
+
+    @Test
+    fun `metadata param is preferred`() {
+        val needsInput = ActionResult.NeedsInput(
+            question = "I need the message to complete this.",
+            metadata = mapOf("param" to "message")
+        )
+
+        assertEquals("message", paramKeyForNeedsInput(needsInput, "SEND_SMS"))
+    }
+
+    @Test
+    fun `communication number prompt without metadata updates contact`() {
+        val needsInput = ActionResult.NeedsInput(
+            question = "I couldn't find 'dad'. What's their phone number?"
+        )
+
+        assertEquals("contact", paramKeyForNeedsInput(needsInput, "SEND_SMS"))
+    }
+
+    @Test
+    fun `non communication prompt without metadata falls back to value`() {
+        val needsInput = ActionResult.NeedsInput(
+            question = "What value should I use?"
+        )
+
+        assertEquals("value", paramKeyForNeedsInput(needsInput, "SET_VOLUME"))
+    }
+}


### PR DESCRIPTION
## Summary
- Generalizes the NeedsInput retry loop so actions can prompt for any missing parameter (not just contact disambiguation) and resume once the user answers, with a bound to avoid infinite prompt loops
- Refreshes Claude model identifiers (Sonnet 4.6, Haiku 4.5, Opus 4.8) across the provider, model fetcher, and settings defaults
- Adds initial unit tests under app/src/test

## Test plan
- [ ] Run app/src/test unit tests (ActionResultTest, ActionSchemaTest, AliasResolverTest, NeedsInputParamKeyTest)
- [ ] Manually verify an action that needs missing input prompts correctly and resumes