### PR TITLE
Palette: Premium Developer-Tool Redesign and Iconography Upgrade

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-07-24 - [Developer Tool Premium Design System Transition]
+**Learning:** Moving static sites from a generic, high-contrast, AI-generator emoji style to a high-quality dark-mode layout (zinc/gray scales `#09090b` + desaturated accents like `#10b981`) requires replacing low-fidelity graphics/emojis with stroke-based inline SVG vector iconography and wrapping real app previews inside custom CSS device mockups to establish a real-product identity.
+**Action:** Always clean out flat-color emojis from navigation, buttons, and titles, replacing them with semantic, high-quality, monochrome inline SVG elements using a stroke width of 1.5px inheriting `currentColor`, and preserve keyboard focus ring readability via `:focus-visible` selectors.

--- a/website/about.html
+++ b/website/about.html
@@ -56,7 +56,10 @@
           <li><a href="privacy.html">Privacy</a></li>
         </ul>
       </li>
-      <li><a href="https://github.com/yashab-cyber/opendroid/releases" target="_blank" class="nav-cta">Download ↓</a></li>
+      <li><a href="https://github.com/yashab-cyber/opendroid/releases" target="_blank" class="nav-cta" aria-label="Download OpenDroid">
+        Download
+        <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align: middle; margin-left: 4px;"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path><polyline points="7 10 12 15 17 10"></polyline><line x1="12" y1="15" x2="12" y2="3"></line></svg>
+      </a></li>
     </ul>
   </div>
 </nav>
@@ -81,8 +84,25 @@
           <p>We're building the most capable, transparent, and privacy-respecting autonomous Android agent — completely open source. While big tech gatekeeps AI agents behind proprietary ecosystems, OpenDroid puts the power directly in your hands.</p>
           <p>No cloud dependencies. No data harvesting. No subscriptions. Just a genuinely intelligent assistant that lives on your device, understands your goals, and acts on them autonomously.</p>
         </div>
-        <div class="about-image">
-          <img src="assets/bot.png" alt="OpenDroid Bot">
+        <div class="reveal" style="display: flex; gap: 16px; flex-direction: column;">
+          <div class="glass-card showcase-card">
+            <div class="showcase-icon" aria-hidden="true">
+              <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"></polygon></svg>
+            </div>
+            <div>
+              <h3>Absolute Speed</h3>
+              <p>We optimize for low latency across every system module. From optimized local speech processing to quick action dispatchers, OpenDroid is built to act fast.</p>
+            </div>
+          </div>
+          <div class="glass-card showcase-card">
+            <div class="showcase-icon" aria-hidden="true">
+              <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"></path></svg>
+            </div>
+            <div>
+              <h3>Deep Local Privacy</h3>
+              <p>We support fully local offline operations. Connect with Ollama, run on-device models, and store all memory tiers in a secure local Room Database.</p>
+            </div>
+          </div>
         </div>
       </div>
     </div>
@@ -99,34 +119,58 @@
       </div>
       <div class="feature-grid">
         <div class="glass-card feature-card reveal">
-          <div class="icon">🔓</div>
-          <h3>Open Source First</h3>
-          <p>Every line of code is public. Audit it, fork it, improve it. Transparency is not optional — it's foundational to trust in AI.</p>
+          <div class="feature-card-content">
+            <div class="icon" aria-hidden="true">
+              <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="11" width="18" height="11" rx="2" ry="2"></rect><path d="M7 11V7a5 5 0 0 1 10 0v4"></path></svg>
+            </div>
+            <h3>Open Source First</h3>
+            <p>Every line of code is public. Audit it, fork it, improve it. Transparency is not optional — it's foundational to trust in AI.</p>
+          </div>
         </div>
         <div class="glass-card feature-card reveal">
-          <div class="icon">🛡️</div>
-          <h3>Privacy by Design</h3>
-          <p>Data stays on your device. No telemetry, no analytics, no cloud sync. You own your data completely.</p>
+          <div class="feature-card-content">
+            <div class="icon" aria-hidden="true">
+              <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"></path></svg>
+            </div>
+            <h3>Privacy by Design</h3>
+            <p>Data stays on your device. No telemetry, no analytics, no cloud sync. You own your data completely.</p>
+          </div>
         </div>
         <div class="glass-card feature-card reveal">
-          <div class="icon">🧩</div>
-          <h3>Modular Architecture</h3>
-          <p>Clean separation of concerns, dependency injection, and extensible modules. Built for contributors to build upon.</p>
+          <div class="feature-card-content">
+            <div class="icon" aria-hidden="true">
+              <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"></path><polyline points="3.27 6.96 12 12.01 20.73 6.96"></polyline><line x1="12" y1="22.08" x2="12" y2="12"></line></svg>
+            </div>
+            <h3>Modular Architecture</h3>
+            <p>Clean separation of concerns, dependency injection, and extensible modules. Built for contributors to build upon.</p>
+          </div>
         </div>
         <div class="glass-card feature-card reveal">
-          <div class="icon">🌍</div>
-          <h3>Community Driven</h3>
-          <p>Shaped by contributors and users. Features are proposed, discussed, and built together in the open.</p>
+          <div class="feature-card-content">
+            <div class="icon" aria-hidden="true">
+              <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"></circle><line x1="2" y1="12" x2="22" y2="12"></line><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"></path></svg>
+            </div>
+            <h3>Community Driven</h3>
+            <p>Shaped by contributors and users. Features are proposed, discussed, and built together in the open.</p>
+          </div>
         </div>
         <div class="glass-card feature-card reveal">
-          <div class="icon">🔌</div>
-          <h3>Provider Agnostic</h3>
-          <p>Bring your own LLM. Support for 10+ providers means you choose the AI brain — or run it fully offline with Ollama.</p>
+          <div class="feature-card-content">
+            <div class="icon" aria-hidden="true">
+              <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"></path><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"></path></svg>
+            </div>
+            <h3>Provider Agnostic</h3>
+            <p>Bring your own LLM. Support for 10+ providers means you choose the AI brain — or run it fully offline with Ollama.</p>
+          </div>
         </div>
         <div class="glass-card feature-card reveal">
-          <div class="icon">⚡</div>
-          <h3>Production Ready</h3>
-          <p>Not a toy or prototype. OpenDroid is engineered for reliability with robust error handling, fallback chains, and re-evaluation.</p>
+          <div class="feature-card-content">
+            <div class="icon" aria-hidden="true">
+              <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"></polygon></svg>
+            </div>
+            <h3>Production Ready</h3>
+            <p>Not a toy or prototype. OpenDroid is engineered for reliability with robust error handling, fallback chains, and re-evaluation.</p>
+          </div>
         </div>
       </div>
     </div>
@@ -139,50 +183,56 @@
     <div class="container">
       <div class="section-header reveal">
         <span class="label">Under the Hood</span>
-        <h2>Technology Stack</h2>
+        <h2>Technology Flow Diagram</h2>
         <p>Built with modern Android best practices and cutting-edge AI integration.</p>
       </div>
-      <div class="arch-grid reveal">
-        <div class="arch-card">
-          <div class="emoji"><img src="assets/bot.png" alt="" aria-hidden="true" style="width: 32px; height: 32px; object-fit: contain;"></div>
-          <h4>Kotlin</h4>
-          <p>100% Kotlin codebase</p>
-        </div>
-        <div class="arch-card">
-          <div class="emoji">🎨</div>
-          <h4>Jetpack Compose</h4>
-          <p>Modern declarative UI</p>
-        </div>
-        <div class="arch-card">
-          <div class="emoji">💉</div>
-          <h4>Dagger-Hilt</h4>
-          <p>Dependency injection</p>
-        </div>
-        <div class="arch-card">
-          <div class="emoji">🗃️</div>
-          <h4>Room Database</h4>
-          <p>Local persistence layer</p>
-        </div>
-        <div class="arch-card">
-          <div class="emoji">🔗</div>
-          <h4>Retrofit + OkHttp</h4>
-          <p>API communication</p>
-        </div>
-        <div class="arch-card">
-          <div class="emoji">♿</div>
-          <h4>Accessibility API</h4>
-          <p>Device automation</p>
-        </div>
-        <div class="arch-card">
-          <div class="emoji">🎤</div>
-          <h4>Android STT</h4>
-          <p>Voice recognition</p>
-        </div>
-        <div class="arch-card">
-          <div class="emoji">📐</div>
-          <h4>Clean Architecture</h4>
-          <p>Modular layered design</p>
-        </div>
+      <div class="arch-diagram-wrapper reveal">
+        <svg class="arch-svg" viewBox="0 0 900 380" xmlns="http://www.w3.org/2000/svg">
+          <defs>
+            <marker id="arrow" viewBox="0 0 10 10" refX="6" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+              <path d="M 0 1.5 L 10 5 L 0 8.5 z" fill="#10b981" />
+            </marker>
+          </defs>
+          <g transform="translate(30, 20)">
+            <rect class="node-rect" width="240" height="60" rx="6" />
+            <text x="120" y="35" font-weight="600" font-size="14" text-anchor="middle">Jetpack Compose UI</text>
+          </g>
+          <g transform="translate(310, 20)">
+            <rect class="node-rect" width="260" height="60" rx="6" style="fill: rgba(16, 185, 129, 0.05); stroke: #10b981;" />
+            <text x="130" y="35" font-weight="700" font-size="14" text-anchor="middle" fill="#10b981">Agent Core (Planner &amp; Resolver)</text>
+          </g>
+          <g transform="translate(610, 20)">
+            <rect class="node-rect" width="260" height="60" rx="6" />
+            <text x="130" y="35" font-weight="600" font-size="14" text-anchor="middle">Accessibility Automation</text>
+          </g>
+          <g transform="translate(30, 150)">
+            <rect class="node-rect" width="240" height="60" rx="6" />
+            <text x="120" y="35" font-weight="600" font-size="14" text-anchor="middle">Voice Engine (STT / TTS)</text>
+          </g>
+          <g transform="translate(310, 150)">
+            <rect class="node-rect" width="260" height="60" rx="6" />
+            <text x="130" y="35" font-weight="600" font-size="14" text-anchor="middle">LLM Gateway (10+ Providers)</text>
+          </g>
+          <g transform="translate(610, 150)">
+            <rect class="node-rect" width="260" height="60" rx="6" />
+            <text x="130" y="35" font-weight="600" font-size="14" text-anchor="middle">System Actions Handler</text>
+          </g>
+          <g transform="translate(170, 280)">
+            <rect class="node-rect" width="260" height="60" rx="6" />
+            <text x="130" y="35" font-weight="600" font-size="14" text-anchor="middle">Room Database &amp; Repositories</text>
+          </g>
+          <g transform="translate(470, 280)">
+            <rect class="node-rect" width="260" height="60" rx="6" />
+            <text x="130" y="35" font-weight="600" font-size="14" text-anchor="middle">Multi-Tier Persistent Memory</text>
+          </g>
+          <path class="flow-line" d="M 150,80 L 150,150" marker-end="url(#arrow)" />
+          <path class="flow-line" d="M 440,80 L 440,150" marker-end="url(#arrow)" />
+          <path class="flow-line" d="M 740,80 L 740,150" marker-end="url(#arrow)" />
+          <path class="flow-line" d="M 270,180 L 310,180" marker-end="url(#arrow)" />
+          <path class="flow-line" d="M 610,180 L 570,180" marker-end="url(#arrow)" />
+          <path class="flow-line" d="M 310,50 Q 230,50 230,150 T 300,280" marker-end="url(#arrow)" />
+          <path class="flow-line" d="M 570,50 Q 600,50 600,150 T 600,280" marker-end="url(#arrow)" />
+        </svg>
       </div>
     </div>
   </section>
@@ -199,8 +249,14 @@
       </div>
       <div class="text-center reveal">
         <div class="cta-buttons">
-          <a href="https://github.com/yashab-cyber" target="_blank" class="btn btn-secondary">🧑‍💻 GitHub Profile</a>
-          <a href="https://discord.gg/knRMyFmvpp" target="_blank" class="btn btn-secondary">💬 Join Discord</a>
+          <a href="https://github.com/yashab-cyber" target="_blank" class="btn btn-secondary">
+            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="margin-right: 6px; vertical-align: middle;"><path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22"></path></svg>
+            GitHub Profile
+          </a>
+          <a href="https://discord.gg/knRMyFmvpp" target="_blank" class="btn btn-secondary">
+            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="margin-right: 6px; vertical-align: middle;"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"></path></svg>
+            Join Discord
+          </a>
         </div>
       </div>
     </div>

--- a/website/contributor.html
+++ b/website/contributor.html
@@ -292,7 +292,10 @@
           <li><a href="privacy.html">Privacy</a></li>
         </ul>
       </li>
-      <li><a href="https://github.com/yashab-cyber/opendroid/releases" target="_blank" class="nav-cta">Download ↓</a></li>
+      <li><a href="https://github.com/yashab-cyber/opendroid/releases" target="_blank" class="nav-cta" aria-label="Download OpenDroid">
+        Download
+        <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align: middle; margin-left: 4px;"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path><polyline points="7 10 12 15 17 10"></polyline><line x1="12" y1="15" x2="12" y2="3"></line></svg>
+      </a></li>
     </ul>
   </div>
 </nav>
@@ -371,9 +374,18 @@
             </div>
           </div>
           <div class="profile-footer" style="flex-wrap: wrap; gap: 8px;">
-            <a href="https://github.com/yashab-cyber" target="_blank" class="btn btn-secondary btn-sm" style="padding: 8px 12px;">🧑‍💻 GitHub</a>
-            <a href="https://www.linkedin.com/in/yashab-alam/" target="_blank" class="btn btn-secondary btn-sm" style="padding: 8px 12px; border-color:#0077b5; color:#0077b5;">🔗 LinkedIn</a>
-            <a href="https://x.com/Yashab_cyber" target="_blank" class="btn btn-secondary btn-sm" style="padding: 8px 12px; border-color:#000; color:#000;">🐦 X</a>
+            <a href="https://github.com/yashab-cyber" target="_blank" class="btn btn-secondary btn-sm" style="padding: 8px 12px;">
+              <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align: middle; margin-right: 4px;"><path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22"></path></svg>
+              GitHub
+            </a>
+            <a href="https://www.linkedin.com/in/yashab-alam/" target="_blank" class="btn btn-secondary btn-sm" style="padding: 8px 12px; border-color:#0077b5; color:#0077b5;">
+              <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align: middle; margin-right: 4px;"><path d="M16 8a6 6 0 0 1 6 6v7h-4v-7a2 2 0 0 0-2-2 2 2 0 0 0-2 2v7h-4v-7a6 6 0 0 1 6-6z"></path><rect x="2" y="9" width="4" height="12"></rect><circle cx="4" cy="4" r="2"></circle></svg>
+              LinkedIn
+            </a>
+            <a href="https://x.com/Yashab_cyber" target="_blank" class="btn btn-secondary btn-sm" style="padding: 8px 12px; border-color:#000; color:#000;">
+              <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align: middle; margin-right: 4px;"><path d="M4 4l11.733 16h4.267l-11.733 -16z M4 20l6.768 -6.768 M20 4l-6.768 6.768"></path></svg>
+              X
+            </a>
           </div>
         </div>
 

--- a/website/css/style.css
+++ b/website/css/style.css
@@ -1,21 +1,21 @@
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Outfit:wght@400;500;600;700;800&display=swap');
 
 :root {
-  --bg-primary: #ffffff;
-  --bg-secondary: #f8f9fa;
-  --bg-tertiary: #f1f3f5;
-  --surface: #ffffff;
-  --surface-hover: #f8f9fa;
-  --surface-border: #e9ecef;
-  --accent: #10b981;
-  --accent-light: #d1fae5;
+  --bg-primary: #09090b; /* Zinc 950 */
+  --bg-secondary: #0f0f11;
+  --bg-tertiary: #18181b; /* Zinc 900 */
+  --surface: #18181b;
+  --surface-hover: #27272a; /* Zinc 800 */
+  --surface-border: rgba(255, 255, 255, 0.08);
+  --accent: #10b981; /* Desaturated emerald green */
+  --accent-light: rgba(16, 185, 129, 0.1);
   --accent-dark: #059669;
-  --text-primary: #111827;
-  --text-body: #4b5563;
-  --text-muted: #9ca3af;
-  --shadow-sm: 0 1px 2px rgba(0,0,0,0.05);
-  --shadow-md: 0 4px 12px rgba(0,0,0,0.08);
-  --shadow-lg: 0 12px 40px rgba(0,0,0,0.1);
+  --text-primary: #f4f4f5; /* Zinc 100 */
+  --text-body: #a1a1aa; /* Zinc 400 */
+  --text-muted: #71717a; /* Zinc 500 */
+  --shadow-sm: 0 1px 2px rgba(0,0,0,0.5);
+  --shadow-md: 0 4px 12px rgba(0,0,0,0.6);
+  --shadow-lg: 0 12px 40px rgba(0,0,0,0.8);
   --radius-sm: 8px;
   --radius-md: 12px;
   --radius-lg: 16px;
@@ -25,6 +25,12 @@
   --nav-height: 64px;
   --max-width: 1140px;
   --transition: 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+/* ── Keyboard Focus Styles ── */
+*:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 4px;
 }
 
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -67,7 +73,7 @@ img { max-width: 100%; height: auto; display: block; }
   position: fixed;
   top: 0; left: 0; right: 0;
   height: var(--nav-height);
-  background: rgba(255,255,255,0.92);
+  background: rgba(9, 9, 11, 0.8);
   backdrop-filter: blur(12px);
   -webkit-backdrop-filter: blur(12px);
   border-bottom: 1px solid var(--surface-border);
@@ -167,15 +173,15 @@ img { max-width: 100%; height: auto; display: block; }
 }
 
 .nav-cta {
-  background: var(--text-primary) !important;
-  color: #fff !important;
+  background: var(--accent) !important;
+  color: #000 !important;
   font-weight: 600 !important;
   padding: 8px 20px !important;
   border-radius: 100px !important;
   font-size: 0.85rem !important;
 }
 .nav-cta:hover {
-  background: #333 !important;
+  background: var(--accent-dark) !important;
   color: #fff !important;
   transform: translateY(-1px);
 }
@@ -211,7 +217,7 @@ img { max-width: 100%; height: auto; display: block; }
     width: 280px;
     height: 100vh;
     flex-direction: column;
-    background: rgba(255,255,255,0.98);
+    background: rgba(9, 9, 11, 0.95);
     backdrop-filter: blur(24px);
     padding: 80px 24px 32px;
     gap: 4px;
@@ -249,23 +255,23 @@ img { max-width: 100%; height: auto; display: block; }
   transition: all var(--transition);
 }
 .btn-primary {
-  background: var(--text-primary);
-  color: #fff;
+  background: var(--accent);
+  color: #000;
 }
 .btn-primary:hover {
-  background: #333;
+  background: var(--accent-dark);
   color: #fff;
   transform: translateY(-2px);
-  box-shadow: var(--shadow-md);
+  box-shadow: 0 0 20px rgba(16, 185, 129, 0.3);
 }
 .btn-secondary {
-  background: var(--bg-primary);
+  background: var(--bg-secondary);
   color: var(--text-primary);
   border: 1px solid var(--surface-border);
 }
 .btn-secondary:hover {
-  background: var(--bg-secondary);
-  border-color: #d1d5db;
+  background: var(--surface-hover);
+  border-color: rgba(255, 255, 255, 0.2);
   color: var(--text-primary);
   transform: translateY(-2px);
 }
@@ -335,28 +341,32 @@ img { max-width: 100%; height: auto; display: block; }
   align-items: center;
 }
 
-.hero-bot-wrapper {
+/* Premium Device Frame Mockup */
+.device-frame-wrapper {
   position: relative;
-  width: 320px;
-  height: 320px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  width: 100%;
+  max-width: 480px;
+  padding: 10px;
+  background: #121214;
+  border-radius: 36px;
+  border: 4px solid #27272a;
+  box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.5), inset 0 1px 0 rgba(255, 255, 255, 0.1);
+  overflow: hidden;
 }
-.hero-bot-wrapper::before {
-  content: '';
-  position: absolute;
-  inset: -20px;
-  background: radial-gradient(circle, rgba(16,185,129,0.1) 0%, transparent 70%);
-  border-radius: 50%;
+
+.device-frame-screen {
+  background: #000;
+  border-radius: 28px;
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  display: block;
+  aspect-ratio: 9 / 19.5;
 }
-.hero-bot-wrapper img {
-  width: 260px;
-  height: 260px;
-  object-fit: contain;
-  position: relative;
-  z-index: 1;
-  animation: float 6s ease-in-out infinite;
+
+.device-frame-screen img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
 }
 
 @keyframes float {
@@ -372,9 +382,8 @@ img { max-width: 100%; height: auto; display: block; }
   .hero-grid { grid-template-columns: 1fr; text-align: center; }
   .hero-description { margin-left: auto; margin-right: auto; }
   .hero-buttons { justify-content: center; }
-  .hero-visual { order: -1; }
-  .hero-bot-wrapper { width: 200px; height: 200px; }
-  .hero-bot-wrapper img { width: 160px; height: 160px; }
+  .hero-visual { order: 1; margin-top: 32px; }
+  .device-frame-wrapper { margin: 0 auto; max-width: 300px; }
 }
 
 /* ── Section ── */
@@ -402,16 +411,20 @@ img { max-width: 100%; height: auto; display: block; }
 
 /* ── Cards ── */
 .glass-card {
-  background: var(--surface);
+  background: rgba(24, 24, 27, 0.7); /* Translucent dark zinc */
   border: 1px solid var(--surface-border);
   border-radius: var(--radius-lg);
   padding: 28px;
   transition: all var(--transition);
+  position: relative;
+  overflow: hidden;
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
 }
 .glass-card:hover {
-  border-color: #d1d5db;
-  transform: translateY(-4px);
-  box-shadow: var(--shadow-lg);
+  border-color: rgba(255, 255, 255, 0.15);
+  transform: translateY(-2px);
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.4);
 }
 
 /* ── Feature Grid ── */
@@ -420,15 +433,27 @@ img { max-width: 100%; height: auto; display: block; }
   grid-template-columns: repeat(3, 1fr);
   gap: 20px;
 }
+.feature-card {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  min-height: 280px;
+}
+.feature-card-content {
+  margin-bottom: 16px;
+}
 .feature-card .icon {
-  width: 44px; height: 44px;
-  background: var(--accent-light);
-  border-radius: var(--radius-sm);
+  width: 40px; height: 40px;
+  color: var(--accent);
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 1.3rem;
   margin-bottom: 16px;
+}
+.feature-card .icon svg {
+  width: 24px;
+  height: 24px;
+  stroke-width: 1.5;
 }
 .feature-card h3 { font-size: 1.1rem; margin-bottom: 8px; }
 .feature-card p { color: var(--text-muted); font-size: 0.9rem; margin-bottom: 0; }
@@ -458,28 +483,58 @@ img { max-width: 100%; height: auto; display: block; }
   margin-top: 6px;
 }
 
-/* ── Architecture ── */
-.arch-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-  gap: 16px;
-}
-.arch-card {
-  background: var(--bg-secondary);
+/* ── Architecture Flow Diagram styling ── */
+.arch-diagram-wrapper {
+  margin-top: 32px;
+  background: rgba(24, 24, 27, 0.7);
   border: 1px solid var(--surface-border);
-  border-radius: var(--radius-md);
-  padding: 20px;
-  text-align: center;
-  transition: all var(--transition);
+  border-radius: var(--radius-xl);
+  padding: 40px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  box-shadow: var(--shadow-lg);
+  overflow-x: auto;
 }
-.arch-card:hover {
-  border-color: #d1d5db;
-  transform: translateY(-2px);
-  box-shadow: var(--shadow-sm);
+
+.arch-svg {
+  width: 100%;
+  max-width: 900px;
+  height: auto;
+  display: block;
 }
-.arch-card .emoji { font-size: 1.8rem; margin-bottom: 10px; }
-.arch-card h4 { font-size: 0.92rem; margin-bottom: 4px; }
-.arch-card p { font-size: 0.8rem; color: var(--text-muted); margin-bottom: 0; }
+
+.arch-svg text {
+  font-family: var(--font-body);
+  fill: var(--text-primary);
+}
+
+.arch-svg .node-rect {
+  fill: #18181b;
+  stroke: var(--surface-border);
+  stroke-width: 1.5;
+  transition: all 0.3s ease;
+}
+
+.arch-svg .node-rect:hover {
+  stroke: var(--accent);
+  fill: #27272a;
+}
+
+.arch-svg .flow-line {
+  stroke: var(--text-muted);
+  stroke-width: 1.5;
+  stroke-dasharray: 4 4;
+  animation: flowAnim 15s linear infinite;
+}
+
+@keyframes flowAnim {
+  to {
+    stroke-dashoffset: -20;
+  }
+}
 
 /* ── CTA ── */
 .cta-section {
@@ -614,15 +669,20 @@ img { max-width: 100%; height: auto; display: block; }
   align-items: start;
 }
 .showcase-card .showcase-icon {
-  width: 56px; height: 56px;
-  background: var(--accent-light);
-  border: 1px solid #a7f3d0;
+  width: 48px; height: 48px;
+  border: 1px solid var(--surface-border);
+  background: var(--bg-secondary);
   border-radius: var(--radius-md);
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 1.4rem;
+  color: var(--accent);
   flex-shrink: 0;
+}
+.showcase-card .showcase-icon svg {
+  width: 24px;
+  height: 24px;
+  stroke-width: 1.5;
 }
 .showcase-card h3 { margin-bottom: 6px; }
 .showcase-card p { color: var(--text-muted); font-size: 0.9rem; margin-bottom: 0; }

--- a/website/features.html
+++ b/website/features.html
@@ -77,7 +77,9 @@
       <div class="feature-showcase">
 
         <div class="glass-card showcase-card reveal" id="showcase-planning">
-          <div class="showcase-icon">🧠</div>
+          <div class="showcase-icon" aria-hidden="true">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M9.5 2A2.5 2.5 0 0 1 12 4.5v15a2.5 2.5 0 0 1-4.96-.44 2.5 2.5 0 0 1 0-3.12 3 3 0 0 1 0-4.88 2.5 2.5 0 0 1 0-3.12A2.5 2.5 0 0 1 9.5 2z"></path><path d="M14.5 2A2.5 2.5 0 0 0 12 4.5v15a2.5 2.5 0 0 0 4.96-.44 2.5 2.5 0 0 0 0-3.12 3 3 0 0 0 0-4.88 2.5 2.5 0 0 0 0-3.12A2.5 2.5 0 0 0 14.5 2z"></path></svg>
+          </div>
           <div>
             <h3>Autonomous Planning & Re-evaluation</h3>
             <p>Give OpenDroid a complex, multi-step goal like <em>"Check if it's going to rain, text my wife I'll be late, and set an alarm for 6 PM"</em> — and it handles everything. The agent decomposes commands into logical sub-tasks, executes each in sequence, verifies the outcome, and dynamically adjusts the remaining steps if something fails or conditions change.</p>
@@ -91,7 +93,9 @@
         </div>
 
         <div class="glass-card showcase-card reveal" id="showcase-device">
-          <div class="showcase-icon">📱</div>
+          <div class="showcase-icon" aria-hidden="true">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="5" y="2" width="14" height="20" rx="2" ry="2"></rect><line x1="12" y1="18" x2="12.01" y2="18"></line></svg>
+          </div>
           <div>
             <h3>Full Device & System Control</h3>
             <p>OpenDroid provides deep integration with Android system APIs, enabling it to control brightness, toggle Wi-Fi and Bluetooth, manage the flashlight, lock the screen, set alarms and timers, create calendar events, translate languages, convert currencies, and much more — all without opening a single app.</p>
@@ -105,7 +109,9 @@
         </div>
 
         <div class="glass-card showcase-card reveal" id="showcase-accessibility">
-          <div class="showcase-icon"><img src="assets/bot.png" alt="" aria-hidden="true" style="width: 32px; height: 32px; object-fit: contain;"></div>
+          <div class="showcase-icon" aria-hidden="true">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"></circle><path d="M8 14s1.5 2 4 2 4-2 4-2"></path><line x1="9" y1="9" x2="9.01" y2="9"></line><line x1="15" y1="9" x2="15.01" y2="9"></line></svg>
+          </div>
           <div>
             <h3>Accessibility Automation</h3>
             <p>When API controls aren't available, OpenDroid leverages Android's Accessibility Service to interact with any app directly. It can click buttons, scroll lists, read screen content, type text, and navigate complex UIs — enabling tasks like sending WhatsApp messages, finding locations in Maps, or posting on social media.</p>
@@ -119,7 +125,9 @@
         </div>
 
         <div class="glass-card showcase-card reveal" id="showcase-vision">
-          <div class="showcase-icon">📸</div>
+          <div class="showcase-icon" aria-hidden="true">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M23 19a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h4l2-3h6l2 3h4a2 2 0 0 1 2 2z"></path><circle cx="12" cy="13" r="4"></circle></svg>
+          </div>
           <div>
             <h3>Vision Engine (Screenshot Analysis)</h3>
             <p>Fully integrated multimodal vision. OpenDroid captures the screen buffer via the Accessibility API (Android 11+) and sends it to the LLM for visual understanding. On older devices or when permissions are limited, it automatically falls back to an accessibility text-scraping mode — ensuring seamless operation across all Android versions.</p>
@@ -133,7 +141,9 @@
         </div>
 
         <div class="glass-card showcase-card reveal" id="showcase-memory">
-          <div class="showcase-icon">🗄️</div>
+          <div class="showcase-icon" aria-hidden="true">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><ellipse cx="12" cy="5" rx="9" ry="3"></ellipse><path d="M3 5V19A9 3 0 0 0 21 19V5"></path><path d="M3 12A9 3 0 0 0 21 12"></path></svg>
+          </div>
           <div>
             <h3>Multi-Tier Persistent Memory</h3>
             <p>OpenDroid doesn't forget. Its four-tier memory system includes: <strong>Working Memory</strong> for current task context, <strong>Episodic Memory</strong> for past action logs, <strong>Semantic Memory</strong> for long-term personal facts extracted via LLM-powered fact mining, and <strong>Procedural Memory</strong> for custom user-defined macro workflows.</p>
@@ -147,7 +157,9 @@
         </div>
 
         <div class="glass-card showcase-card reveal" id="showcase-voice">
-          <div class="showcase-icon">🎙️</div>
+          <div class="showcase-icon" aria-hidden="true">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 1a3 3 0 0 0-3 3v8a3 3 0 0 0 6 0V4a3 3 0 0 0-3-3z"></path><path d="M19 10v2a7 7 0 0 1-14 0v-2"></path><line x1="12" y1="19" x2="12" y2="23"></line><line x1="8" y1="23" x2="16" y2="23"></line></svg>
+          </div>
           <div>
             <h3>Wake Word & Voice Interface</h3>
             <p>Go completely hands-free with offline wake word detection, Android's native speech recognition engine, and high-fidelity text-to-speech output. OpenDroid also supports premium ElevenLabs voices as a TTS fallback for a more natural conversational experience.</p>
@@ -161,7 +173,9 @@
         </div>
 
         <div class="glass-card showcase-card reveal" id="showcase-comms">
-          <div class="showcase-icon">📞</div>
+          <div class="showcase-icon" aria-hidden="true">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6 19.79 19.79 0 0 1-3.07-8.67A2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72 12.84 12.84 0 0 0 .7 2.81 2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 6 6l1.27-1.27a2 2 0 0 1 2.11-.45 12.84 12.84 0 0 0 2.81.7A2 2 0 0 1 22 16.92z"></path></svg>
+          </div>
           <div>
             <h3>Robust Calls & SMS</h3>
             <p>Zero-refusal communication with intelligent fallback chains. OpenDroid resolves contacts by name, makes calls via TelephonyManager, and sends SMS programmatically. If permissions are missing, it gracefully falls back to system dialer and SMS composer intents — ensuring the task always gets done.</p>
@@ -175,7 +189,9 @@
         </div>
 
         <div class="glass-card showcase-card reveal" id="showcase-llm">
-          <div class="showcase-icon">🔗</div>
+          <div class="showcase-icon" aria-hidden="true">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"></path><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"></path></svg>
+          </div>
           <div>
             <h3>10+ LLM Provider Support</h3>
             <p>Bring your own AI brain. OpenDroid supports Anthropic Claude, OpenAI GPT, Google Gemini, Groq, Mistral, OpenRouter, Together AI, Cohere, DeepSeek — and fully offline operation via Ollama with a custom server URL. Switch providers instantly from the settings screen.</p>
@@ -190,7 +206,9 @@
         </div>
 
         <div class="glass-card showcase-card reveal" id="showcase-ui">
-          <div class="showcase-icon">🎨</div>
+          <div class="showcase-icon" aria-hidden="true">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 14.7255 3.09032 17.1962 4.85857 19C5.03578 19.1772 5.08786 19.4431 4.97323 19.6644C4.34149 20.8844 4 22.25 4 23.682C4 23.8576 4.14238 24 4.318 24C6.54162 24 8.57242 22.9976 9.94635 21.4111C10.108 21.2244 10.3667 21.1578 10.5966 21.2464C11.0567 21.3467 11.5234 21.3976 12 21.3976L12 22Z"></path></svg>
+          </div>
           <div>
             <h3>Premium Glassmorphic Design</h3>
             <p>Built with Jetpack Compose featuring a futuristic deep navy and neon green design system. Enjoy custom pulsing audio orb indicators, live latency benchmarks, animated plan visualizations, and a polished chat interface that makes AI interaction feel premium.</p>

--- a/website/index.html
+++ b/website/index.html
@@ -207,7 +207,7 @@
       <div class="glass-card feature-card reveal" id="feat-memory">
         <div class="feature-card-content">
           <div class="icon" aria-hidden="true">
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><meta name="lucide-metadata" content="database"/><ellipse cx="12" cy="5" rx="9" ry="3"></ellipse><path d="M3 5V19A9 3 0 0 0 21 19V5"></path><path d="M3 12A9 3 0 0 0 21 12"></path></svg>
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><ellipse cx="12" cy="5" rx="9" ry="3"></ellipse><path d="M3 5V19A9 3 0 0 0 21 19V5"></path><path d="M3 12A9 3 0 0 0 21 12"></path></svg>
           </div>
           <h3>Multi-Tier Memory</h3>
           <p>Working, episodic, semantic, and procedural memory systems for persistent context and user preference learning.</p>

--- a/website/index.html
+++ b/website/index.html
@@ -65,7 +65,10 @@
           <li><a href="privacy.html">Privacy</a></li>
         </ul>
       </li>
-      <li><a href="https://github.com/yashab-cyber/opendroid/releases" target="_blank" class="nav-cta">Download ↓</a></li>
+      <li><a href="https://github.com/yashab-cyber/opendroid/releases" target="_blank" class="nav-cta" aria-label="Download OpenDroid">
+        Download
+        <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align: middle; margin-left: 4px;"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path><polyline points="7 10 12 15 17 10"></polyline><line x1="12" y1="15" x2="12" y2="3"></line></svg>
+      </a></li>
     </ul>
   </div>
 </nav>
@@ -81,27 +84,30 @@
         </div>
         <h1>Your Open<br><span class="gradient-text">Autonomous Android</span><br>Agent</h1>
         <p class="hero-description">
-          A production-ready AI assistant that breaks complex goals into sequential sub-tasks,
-          executes them through direct device controls, and dynamically replans when conditions change.
+          A production-ready, modular AI assistant designed to execute complex device workflows and automate multi-step tasks autonomously.
         </p>
         <div class="hero-buttons">
-          <a href="https://github.com/yashab-cyber/opendroid/releases" class="btn btn-primary" id="download-btn">
-            ⬇ Download APK
+          <a href="https://github.com/yashab-cyber/opendroid/releases" class="btn btn-primary" id="download-btn" aria-label="Download APK">
+            <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path><polyline points="7 10 12 15 17 10"></polyline><line x1="12" y1="15" x2="12" y2="3"></line></svg>
+            Download APK
           </a>
-          <a href="https://indusapp.store/wphbqhzu" target="_blank" class="indus-badge-link" id="indus-badge-btn">
+          <a href="https://indusapp.store/wphbqhzu" target="_blank" class="indus-badge-link" id="indus-badge-btn" aria-label="Get it on Indus Appstore">
             <img src="assets/indus-badge.png" alt="Get it on Indus Appstore" class="indus-badge-img">
           </a>
           <a href="https://www.producthunt.com/products/opendroid?embed=true&amp;utm_source=badge-featured&amp;utm_medium=badge&amp;utm_campaign=badge-opendroid" target="_blank" rel="noopener noreferrer" class="producthunt-badge-link" id="producthunt-badge-btn">
             <img src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1205420&amp;theme=light&amp;t=1784972318707" alt="Opendroid - Autonomous A.I agent for Android. | Product Hunt" width="250" height="54">
           </a>
-          <a href="https://github.com/yashab-cyber/opendroid" target="_blank" class="btn btn-secondary" id="github-btn">
-            ⭐ Star on GitHub
+          <a href="https://github.com/yashab-cyber/opendroid" target="_blank" class="btn btn-secondary" id="github-btn" aria-label="Star on GitHub">
+            <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"></polygon></svg>
+            Star on GitHub
           </a>
         </div>
       </div>
       <div class="hero-visual">
-        <div class="hero-bot-wrapper">
-          <img src="assets/bot.png" alt="OpenDroid AI Bot" id="hero-bot">
+        <div class="device-frame-wrapper">
+          <div class="device-frame-screen">
+            <img src="assets/screenshot/Screenshot_20260528-234508_OpenDroid.png" alt="OpenDroid Interface Screen Preview">
+          </div>
         </div>
       </div>
     </div>
@@ -163,34 +169,58 @@
     </div>
     <div class="feature-grid">
       <div class="glass-card feature-card reveal" id="feat-planning">
-        <div class="icon">🧠</div>
-        <h3>Autonomous Planning</h3>
-        <p>Breaks complex multi-step commands into logical sub-tasks, executes sequentially, and dynamically replans on failure.</p>
+        <div class="feature-card-content">
+          <div class="icon" aria-hidden="true">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M9.5 2A2.5 2.5 0 0 1 12 4.5v15a2.5 2.5 0 0 1-4.96-.44 2.5 2.5 0 0 1 0-3.12 3 3 0 0 1 0-4.88 2.5 2.5 0 0 1 0-3.12A2.5 2.5 0 0 1 9.5 2z"></path><path d="M14.5 2A2.5 2.5 0 0 0 12 4.5v15a2.5 2.5 0 0 0 4.96-.44 2.5 2.5 0 0 0 0-3.12 3 3 0 0 0 0-4.88 2.5 2.5 0 0 0 0-3.12A2.5 2.5 0 0 0 14.5 2z"></path></svg>
+          </div>
+          <h3>Autonomous Planning</h3>
+          <p>Breaks complex multi-step commands into logical sub-tasks, executes sequentially, and dynamically replans on failure.</p>
+        </div>
       </div>
       <div class="glass-card feature-card reveal" id="feat-device">
-        <div class="icon">📱</div>
-        <h3>Full Device Control</h3>
-        <p>Brightness, Wi-Fi, Bluetooth, flashlight, alarms, timers, calendar, calls, SMS — all controlled autonomously.</p>
+        <div class="feature-card-content">
+          <div class="icon" aria-hidden="true">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="5" y="2" width="14" height="20" rx="2" ry="2"></rect><line x1="12" y1="18" x2="12.01" y2="18"></line></svg>
+          </div>
+          <h3>Full Device Control</h3>
+          <p>Brightness, Wi-Fi, Bluetooth, flashlight, alarms, timers, calendar, calls, SMS — all controlled autonomously.</p>
+        </div>
       </div>
       <div class="glass-card feature-card reveal" id="feat-accessibility">
-        <div class="icon"><img src="assets/bot.png" alt="" aria-hidden="true" style="width: 24px; height: 24px; object-fit: contain;"></div>
-        <h3>Accessibility Automation</h3>
-        <p>Clicks, scrolls, reads screens, and automates third-party apps like WhatsApp and Maps via Accessibility Services.</p>
+        <div class="feature-card-content">
+          <div class="icon" aria-hidden="true">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"></circle><path d="M8 14s1.5 2 4 2 4-2 4-2"></path><line x1="9" y1="9" x2="9.01" y2="9"></line><line x1="15" y1="9" x2="15.01" y2="9"></line></svg>
+          </div>
+          <h3>Accessibility Automation</h3>
+          <p>Clicks, scrolls, reads screens, and automates third-party apps like WhatsApp and Maps via Accessibility Services.</p>
+        </div>
       </div>
       <div class="glass-card feature-card reveal" id="feat-vision">
-        <div class="icon">📸</div>
-        <h3>Vision Engine</h3>
-        <p>Captures and analyzes screenshots using multimodal LLMs. Falls back to text-scraping on older devices.</p>
+        <div class="feature-card-content">
+          <div class="icon" aria-hidden="true">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M23 19a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h4l2-3h6l2 3h4a2 2 0 0 1 2 2z"></path><circle cx="12" cy="13" r="4"></circle></svg>
+          </div>
+          <h3>Vision Engine</h3>
+          <p>Captures and analyzes screenshots using multimodal LLMs. Falls back to text-scraping on older devices.</p>
+        </div>
       </div>
       <div class="glass-card feature-card reveal" id="feat-memory">
-        <div class="icon">🗄️</div>
-        <h3>Multi-Tier Memory</h3>
-        <p>Working, episodic, semantic, and procedural memory systems for persistent context and user preference learning.</p>
+        <div class="feature-card-content">
+          <div class="icon" aria-hidden="true">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><meta name="lucide-metadata" content="database"/><ellipse cx="12" cy="5" rx="9" ry="3"></ellipse><path d="M3 5V19A9 3 0 0 0 21 19V5"></path><path d="M3 12A9 3 0 0 0 21 12"></path></svg>
+          </div>
+          <h3>Multi-Tier Memory</h3>
+          <p>Working, episodic, semantic, and procedural memory systems for persistent context and user preference learning.</p>
+        </div>
       </div>
       <div class="glass-card feature-card reveal" id="feat-voice">
-        <div class="icon">🎙️</div>
-        <h3>Voice Interface</h3>
-        <p>Hands-free wake word detection, speech recognition, and high-fidelity TTS with ElevenLabs fallback support.</p>
+        <div class="feature-card-content">
+          <div class="icon" aria-hidden="true">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 1a3 3 0 0 0-3 3v8a3 3 0 0 0 6 0V4a3 3 0 0 0-3-3z"></path><path d="M19 10v2a7 7 0 0 1-14 0v-2"></path><line x1="12" y1="19" x2="12" y2="23"></line><line x1="8" y1="23" x2="16" y2="23"></line></svg>
+          </div>
+          <h3>Voice Interface</h3>
+          <p>Hands-free wake word detection, speech recognition, and high-fidelity TTS with ElevenLabs fallback support.</p>
+        </div>
       </div>
     </div>
     <div class="text-center mt-4 reveal">
@@ -233,50 +263,69 @@
   <div class="container">
     <div class="section-header reveal">
       <span class="label">Architecture</span>
-      <h2>Modular, Clean &amp; Extensible</h2>
-      <p>Built with Dagger-Hilt dependency injection, clean architecture layers, and Jetpack Compose UI.</p>
+      <h2>Modular, Clean &amp; Extensible Flow</h2>
+      <p>A visual breakdown of OpenDroid's core modular system — connecting services, models, databases, and UI components.</p>
     </div>
-    <div class="arch-grid reveal">
-      <div class="arch-card">
-        <div class="emoji">♿</div>
-        <h4>Accessibility</h4>
-        <p>Services & app automators</p>
-      </div>
-      <div class="arch-card">
-        <div class="emoji">⚡</div>
-        <h4>Actions</h4>
-        <p>System, comms, productivity</p>
-      </div>
-      <div class="arch-card">
-        <div class="emoji">🧠</div>
-        <h4>Agent Core</h4>
-        <p>Planner, classifier, resolver</p>
-      </div>
-      <div class="arch-card">
-        <div class="emoji">🔗</div>
-        <h4>LLM Layer</h4>
-        <p>10+ provider integrations</p>
-      </div>
-      <div class="arch-card">
-        <div class="emoji">💾</div>
-        <h4>Memory</h4>
-        <p>4-tier persistent memory</p>
-      </div>
-      <div class="arch-card">
-        <div class="emoji">🎤</div>
-        <h4>Voice</h4>
-        <p>Wake word, STT, TTS</p>
-      </div>
-      <div class="arch-card">
-        <div class="emoji">🗃️</div>
-        <h4>Data</h4>
-        <p>Room DB, repos, models</p>
-      </div>
-      <div class="arch-card">
-        <div class="emoji">🎨</div>
-        <h4>UI</h4>
-        <p>Compose screens & themes</p>
-      </div>
+    <div class="arch-diagram-wrapper reveal">
+      <svg class="arch-svg" viewBox="0 0 900 380" xmlns="http://www.w3.org/2000/svg">
+        <!-- Definitions for markers and filters -->
+        <defs>
+          <marker id="arrow" viewBox="0 0 10 10" refX="6" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+            <path d="M 0 1.5 L 10 5 L 0 8.5 z" fill="#10b981" />
+          </marker>
+        </defs>
+
+        <!-- UI / Presentation Layer (Top) -->
+        <g transform="translate(30, 20)">
+          <rect class="node-rect" width="240" height="60" rx="6" />
+          <text x="120" y="35" font-weight="600" font-size="14" text-anchor="middle">Jetpack Compose UI</text>
+        </g>
+        <g transform="translate(310, 20)">
+          <rect class="node-rect" width="260" height="60" rx="6" style="fill: rgba(16, 185, 129, 0.05); stroke: #10b981;" />
+          <text x="130" y="35" font-weight="700" font-size="14" text-anchor="middle" fill="#10b981">Agent Core (Planner &amp; Resolver)</text>
+        </g>
+        <g transform="translate(610, 20)">
+          <rect class="node-rect" width="260" height="60" rx="6" />
+          <text x="130" y="35" font-weight="600" font-size="14" text-anchor="middle">Accessibility Automation</text>
+        </g>
+
+        <!-- Middle Layers (Services & Processors) -->
+        <g transform="translate(30, 150)">
+          <rect class="node-rect" width="240" height="60" rx="6" />
+          <text x="120" y="35" font-weight="600" font-size="14" text-anchor="middle">Voice Engine (STT / TTS)</text>
+        </g>
+        <g transform="translate(310, 150)">
+          <rect class="node-rect" width="260" height="60" rx="6" />
+          <text x="130" y="35" font-weight="600" font-size="14" text-anchor="middle">LLM Gateway (10+ Providers)</text>
+        </g>
+        <g transform="translate(610, 150)">
+          <rect class="node-rect" width="260" height="60" rx="6" />
+          <text x="130" y="35" font-weight="600" font-size="14" text-anchor="middle">System Actions Handler</text>
+        </g>
+
+        <!-- Base Layers (Data & Memory) -->
+        <g transform="translate(170, 280)">
+          <rect class="node-rect" width="260" height="60" rx="6" />
+          <text x="130" y="35" font-weight="600" font-size="14" text-anchor="middle">Room Database &amp; Repositories</text>
+        </g>
+        <g transform="translate(470, 280)">
+          <rect class="node-rect" width="260" height="60" rx="6" />
+          <text x="130" y="35" font-weight="600" font-size="14" text-anchor="middle">Multi-Tier Persistent Memory</text>
+        </g>
+
+        <!-- Connection Lines / Flows (Top to Middle) -->
+        <path class="flow-line" d="M 150,80 L 150,150" marker-end="url(#arrow)" />
+        <path class="flow-line" d="M 440,80 L 440,150" marker-end="url(#arrow)" />
+        <path class="flow-line" d="M 740,80 L 740,150" marker-end="url(#arrow)" />
+
+        <!-- Bi-directional connections in Middle Layer -->
+        <path class="flow-line" d="M 270,180 L 310,180" marker-end="url(#arrow)" />
+        <path class="flow-line" d="M 610,180 L 570,180" marker-end="url(#arrow)" />
+
+        <!-- Connections from Middle to Base -->
+        <path class="flow-line" d="M 310,50 Q 230,50 230,150 T 300,280" marker-end="url(#arrow)" />
+        <path class="flow-line" d="M 570,50 Q 600,50 600,150 T 600,280" marker-end="url(#arrow)" />
+      </svg>
     </div>
   </div>
 </section>

--- a/website/privacy.html
+++ b/website/privacy.html
@@ -56,7 +56,10 @@
           <li><a href="privacy.html">Privacy</a></li>
         </ul>
       </li>
-      <li><a href="https://github.com/yashab-cyber/opendroid/releases" target="_blank" class="nav-cta">Download ↓</a></li>
+      <li><a href="https://github.com/yashab-cyber/opendroid/releases" target="_blank" class="nav-cta" aria-label="Download OpenDroid">
+        Download
+        <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align: middle; margin-left: 4px;"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path><polyline points="7 10 12 15 17 10"></polyline><line x1="12" y1="15" x2="12" y2="3"></line></svg>
+      </a></li>
     </ul>
   </div>
 </nav>

--- a/website/security.html
+++ b/website/security.html
@@ -56,7 +56,10 @@
           <li><a href="privacy.html">Privacy</a></li>
         </ul>
       </li>
-      <li><a href="https://github.com/yashab-cyber/opendroid/releases" target="_blank" class="nav-cta">Download ↓</a></li>
+      <li><a href="https://github.com/yashab-cyber/opendroid/releases" target="_blank" class="nav-cta" aria-label="Download OpenDroid">
+        Download
+        <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align: middle; margin-left: 4px;"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path><polyline points="7 10 12 15 17 10"></polyline><line x1="12" y1="15" x2="12" y2="3"></line></svg>
+      </a></li>
     </ul>
   </div>
 </nav>

--- a/website/support.html
+++ b/website/support.html
@@ -57,7 +57,10 @@
           <li><a href="privacy.html">Privacy</a></li>
         </ul>
       </li>
-      <li><a href="https://github.com/yashab-cyber/opendroid/releases" target="_blank" class="nav-cta">Download ↓</a></li>
+      <li><a href="https://github.com/yashab-cyber/opendroid/releases" target="_blank" class="nav-cta" aria-label="Download OpenDroid">
+        Download
+        <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align: middle; margin-left: 4px;"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path><polyline points="7 10 12 15 17 10"></polyline><line x1="12" y1="15" x2="12" y2="3"></line></svg>
+      </a></li>
     </ul>
   </div>
 </nav>
@@ -77,25 +80,33 @@
     <div class="container">
       <div class="contact-grid reveal">
         <div class="glass-card contact-card" id="contact-discord">
-          <div class="icon">💬</div>
+          <div class="icon" aria-hidden="true">
+            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" style="color: var(--accent);"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"></path></svg>
+          </div>
           <h3>Discord Community</h3>
           <p>Join our active community for real-time help, feature discussions, and updates.</p>
           <a href="https://discord.gg/knRMyFmvpp" target="_blank" class="btn btn-primary">Join Server</a>
         </div>
         <div class="glass-card contact-card" id="contact-github">
-          <div class="icon">🐛</div>
+          <div class="icon" aria-hidden="true">
+            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" style="color: var(--accent);"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"></path></svg>
+          </div>
           <h3>Report a Bug</h3>
           <p>Found a bug? Open an issue on GitHub with steps to reproduce and device info.</p>
           <a href="https://github.com/yashab-cyber/opendroid/issues/new" target="_blank" class="btn btn-secondary">Open Issue</a>
         </div>
         <div class="glass-card contact-card" id="contact-email">
-          <div class="icon">📧</div>
+          <div class="icon" aria-hidden="true">
+            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" style="color: var(--accent);"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"></path><polyline points="22,6 12,13 2,6"></polyline></svg>
+          </div>
           <h3>Email</h3>
           <p>For security vulnerabilities or private inquiries, email us directly.</p>
           <a href="mailto:opendroid.ai@gmail.com" class="btn btn-secondary">Send Email</a>
         </div>
         <div class="glass-card contact-card" id="contact-indus">
-          <div class="icon">🏬</div>
+          <div class="icon" aria-hidden="true">
+            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" style="color: var(--accent);"><rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect><line x1="9" y1="3" x2="9" y2="21"></line></svg>
+          </div>
           <h3>Indus Appstore</h3>
           <p>Scan to download or visit the store directly to install OpenDroid.</p>
           <div class="qr-wrapper">

--- a/website/terms.html
+++ b/website/terms.html
@@ -56,7 +56,10 @@
           <li><a href="privacy.html">Privacy</a></li>
         </ul>
       </li>
-      <li><a href="https://github.com/yashab-cyber/opendroid/releases" target="_blank" class="nav-cta">Download ↓</a></li>
+      <li><a href="https://github.com/yashab-cyber/opendroid/releases" target="_blank" class="nav-cta" aria-label="Download OpenDroid">
+        Download
+        <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align: middle; margin-left: 4px;"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path><polyline points="7 10 12 15 17 10"></polyline><line x1="12" y1="15" x2="12" y2="3"></line></svg>
+      </a></li>
     </ul>
   </div>
 </nav>


### PR DESCRIPTION
Ports the dark-mode/zinc palette redesign (emoji -> stroke SVG icons, focus-visible outlines, hero device mockup, animated architecture diagram) already shipped on my fork. Includes one follow-up fix: removed a stray `<meta name="lucide-metadata">` tag left over from copy-pasting a Lucide icon into the Multi-Tier Memory SVG (invalid inside `<svg>`, harmless in browsers but not clean).

Scoped to just this redesign work — no unrelated fork-only changes included.