### PR TITLE
fix: Android permissions screen and agent/chat reliability

### DIFF
--- a/app/src/main/java/com/opendroid/ai/accessibility/GenericAppAutomator.kt
+++ b/app/src/main/java/com/opendroid/ai/accessibility/GenericAppAutomator.kt
@@ -1,27 +1,55 @@
 package com.opendroid.ai.accessibility
 
 import android.accessibilityservice.AccessibilityService
+import android.os.SystemClock
+import kotlinx.coroutines.delay
 
 object GenericAppAutomator {
 
-    fun clickText(text: String): Boolean {
-        val service = OpenDroidAccessibilityService.getInstance() ?: return false
-        return service.findAndClick(text)
+    private const val RETRY_TIMEOUT_MS = 5000L
+    private const val RETRY_INTERVAL_MS = 300L
+
+    /**
+     * Freshly launched apps (e.g. right after OPEN_APP or a self-contained action
+     * like PLAY_YOUTUBE) are often still cold-starting when the next automation step
+     * runs, so their UI elements aren't laid out yet. Polls [attempt] every
+     * [RETRY_INTERVAL_MS] until it succeeds or [RETRY_TIMEOUT_MS] elapses, instead of
+     * giving up after a single immediate try.
+     */
+    private suspend fun retryUntilTimeout(attempt: () -> Boolean): Boolean {
+        val deadline = SystemClock.elapsedRealtime() + RETRY_TIMEOUT_MS
+        while (true) {
+            if (attempt()) return true
+            if (SystemClock.elapsedRealtime() >= deadline) return false
+            delay(RETRY_INTERVAL_MS)
+        }
     }
 
-    fun clickId(viewId: String): Boolean {
-        val service = OpenDroidAccessibilityService.getInstance() ?: return false
-        return service.findAndClickById(viewId)
+    suspend fun clickText(text: String): Boolean = retryUntilTimeout {
+        OpenDroidAccessibilityService.getInstance()?.findAndClick(text) == true
     }
 
-    fun typeText(searchText: String, content: String): Boolean {
-        val service = OpenDroidAccessibilityService.getInstance() ?: return false
-        return service.findAndType(searchText, content)
+    suspend fun clickId(viewId: String): Boolean = retryUntilTimeout {
+        OpenDroidAccessibilityService.getInstance()?.findAndClickById(viewId) == true
     }
 
-    fun typeId(viewId: String, content: String): Boolean {
+    suspend fun typeText(searchText: String, content: String): Boolean = retryUntilTimeout {
+        OpenDroidAccessibilityService.getInstance()?.findAndType(searchText, content) == true
+    }
+
+    suspend fun typeId(viewId: String, content: String): Boolean = retryUntilTimeout {
+        OpenDroidAccessibilityService.getInstance()?.findAndTypeById(viewId, content) == true
+    }
+
+    /**
+     * Performs the IME 'enter/search/go' action on the currently focused editable
+     * field — submits a search box after [typeText]/[typeId] fills it in. No polling
+     * here: it's meant to run immediately after a successful type, once the field is
+     * already known to exist.
+     */
+    fun pressEnter(): Boolean {
         val service = OpenDroidAccessibilityService.getInstance() ?: return false
-        return service.findAndTypeById(viewId, content)
+        return service.performImeEnter()
     }
 
     fun scrapeScreen(): String {

--- a/app/src/main/java/com/opendroid/ai/accessibility/OpenDroidAccessibilityService.kt
+++ b/app/src/main/java/com/opendroid/ai/accessibility/OpenDroidAccessibilityService.kt
@@ -57,6 +57,7 @@ class OpenDroidAccessibilityService : AccessibilityService() {
     private var isButtonAdded = false
     private var isDeviceLocked = false
     private var showFloatingButtonSetting = false
+    private val imeSubmitLabels = listOf("search", "go", "send", "done", "submit", "ok", "enter")
 
     /**
      * BroadcastReceiver that tracks device lock/unlock state.
@@ -476,6 +477,56 @@ class OpenDroidAccessibilityService : AccessibilityService() {
                 return true
             }
             node.recycle()
+        }
+        return false
+    }
+
+    /**
+     * Performs the IME 'enter/search/go' action on the currently focused editable
+     * field — used to submit a search box after TYPE_TEXT/TYPE_ID types into it.
+     * Uses AccessibilityNodeInfo.ACTION_IME_ENTER on API 30+ (the only reliable way
+     * to trigger the IME action programmatically). On older API levels — or if that
+     * fails — falls back to tapping a nearby clickable control whose label reads like
+     * a submit action ("search", "go", "send", "done", "submit", "ok", "enter").
+     */
+    fun performImeEnter(): Boolean {
+        val focusedNode = rootInActiveWindow?.findFocus(AccessibilityNodeInfo.FOCUS_INPUT)
+        val success = if (focusedNode != null) {
+            try {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                    focusedNode.performAction(AccessibilityNodeInfo.AccessibilityAction.ACTION_IME_ENTER.id)
+                } else {
+                    false
+                }
+            } finally {
+                focusedNode.recycle()
+            }
+        } else {
+            false
+        }
+        return success || performSubmitFallback()
+    }
+
+    private fun performSubmitFallback(): Boolean {
+        val rootNode = rootInActiveWindow ?: return false
+        val result = findSubmitNode(rootNode, imeSubmitLabels)
+        rootNode.recycle()
+        return result
+    }
+
+    private fun findSubmitNode(node: AccessibilityNodeInfo, labels: List<String>): Boolean {
+        val text = node.text?.toString()?.lowercase()
+        val contentDesc = node.contentDescription?.toString()?.lowercase()
+        if (node.isClickable && (labels.contains(text) || labels.contains(contentDesc))) {
+            return node.performAction(AccessibilityNodeInfo.ACTION_CLICK)
+        }
+        for (i in 0 until node.childCount) {
+            val child = node.getChild(i) ?: continue
+            if (findSubmitNode(child, labels)) {
+                child.recycle()
+                return true
+            }
+            child.recycle()
         }
         return false
     }

--- a/app/src/main/java/com/opendroid/ai/actions/ActionAutoMapper.kt
+++ b/app/src/main/java/com/opendroid/ai/actions/ActionAutoMapper.kt
@@ -260,6 +260,20 @@ class ActionAutoMapper @Inject constructor() {
         "CHANGE_BRIGHTNESS"       to "SET_BRIGHTNESS",
         "ADJUST_BRIGHTNESS"       to "SET_BRIGHTNESS",
 
+        // ── Wait/delay variants (WAIT after OPEN_APP, before automation steps) ──
+        "SLEEP"                   to "WAIT",
+        "DELAY"                   to "WAIT",
+        "PAUSE_EXECUTION"         to "WAIT",
+        "WAIT_FOR_APP"            to "WAIT",
+        "WAIT_SECONDS"            to "WAIT",
+
+        // ── Submit/Enter variants (submit a search box after TYPE_TEXT/TYPE_ID) ──
+        "SUBMIT"                  to "PRESS_ENTER",
+        "SUBMIT_SEARCH"           to "PRESS_ENTER",
+        "PRESS_SEARCH"            to "PRESS_ENTER",
+        "IME_ENTER"               to "PRESS_ENTER",
+        "TAP_ENTER"               to "PRESS_ENTER",
+
         // ── Navigation/directions variants ──────────────────────────
         "NAVIGATE"                to "GET_DIRECTIONS",
         "DIRECTIONS"              to "GET_DIRECTIONS",
@@ -586,6 +600,26 @@ class ActionAutoMapper @Inject constructor() {
                     ?: originalParams["city"]
                     ?: originalParams["place"]
                 if (location != null) mapOf("location" to location) else originalParams
+            }
+
+            "WAIT" -> {
+                val msValue = originalParams["durationMs"]
+                    ?: originalParams["duration"]
+                    ?: originalParams["ms"]
+                    ?: originalParams["milliseconds"]
+                val secondsValue = originalParams["seconds"] ?: originalParams["time"]
+                when {
+                    msValue != null -> mapOf("durationMs" to msValue)
+                    secondsValue != null -> {
+                        val seconds = secondsValue.toDoubleOrNull()
+                        if (seconds != null) {
+                            mapOf("durationMs" to (seconds * 1000).toLong().toString())
+                        } else {
+                            originalParams
+                        }
+                    }
+                    else -> originalParams
+                }
             }
 
             else -> originalParams

--- a/app/src/main/java/com/opendroid/ai/actions/AdvancedControlActions.kt
+++ b/app/src/main/java/com/opendroid/ai/actions/AdvancedControlActions.kt
@@ -28,11 +28,15 @@ import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
+import kotlinx.coroutines.delay
 
 @Singleton
 class AdvancedControlActions @Inject constructor() {
 
     companion object {
+        /** Hard ceiling for the WAIT action so a plan can never stall execution indefinitely. */
+        private const val MAX_WAIT_MS = 10_000L
+
         private fun hasStoragePermission(context: Context): Boolean {
             return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
                 Environment.isExternalStorageManager()
@@ -118,7 +122,9 @@ class AdvancedControlActions @Inject constructor() {
         TypeIdAction(),
         ScrollAction(),
         GetScreenTextAction(),
-        ClickCoordinatesAction()
+        ClickCoordinatesAction(),
+        PressEnterAction(),
+        WaitAction()
     )
 
     private class GetSystemInfoAction : Action {
@@ -524,6 +530,24 @@ class AdvancedControlActions @Inject constructor() {
             val y = params["y"]?.toFloatOrNull() ?: return ActionResult(false, null, "y coordinate is missing or invalid")
             val success = GenericAppAutomator.clickCoordinates(x, y)
             return ActionResult(success, if (success) "Tapped there!" else "Couldn't tap at that spot.", null)
+        }
+    }
+
+    private class PressEnterAction : Action {
+        override val name: String = "PRESS_ENTER"
+        override suspend fun execute(params: Map<String, String>, context: Context): ActionResult {
+            val success = GenericAppAutomator.pressEnter()
+            return ActionResult(success, if (success) "Submitted!" else "Couldn't find a focused field to submit.", null)
+        }
+    }
+
+    private class WaitAction : Action {
+        override val name: String = "WAIT"
+        override suspend fun execute(params: Map<String, String>, context: Context): ActionResult {
+            val requestedMs = params["durationMs"]?.toLongOrNull() ?: 2000L
+            val clampedMs = requestedMs.coerceIn(0L, MAX_WAIT_MS)
+            delay(clampedMs)
+            return ActionResult(true, "Waited ${clampedMs}ms.", null)
         }
     }
 

--- a/app/src/main/java/com/opendroid/ai/core/agent/ActionSchema.kt
+++ b/app/src/main/java/com/opendroid/ai/core/agent/ActionSchema.kt
@@ -1029,6 +1029,29 @@ object ActionSchema {
             examples = listOf("click at position"),
             category = ActionCategory.ADVANCED
         ),
+        ActionDefinition(
+            name = "PRESS_ENTER",
+            description = """Performs the IME 'enter/search/go' action on the currently
+                focused text field to submit it. ALWAYS use this after TYPE_TEXT or
+                TYPE_ID when the goal is to run a search — typing text alone does not
+                submit it.""",
+            params = emptyList(),
+            examples = listOf("press enter", "submit the search", "press search"),
+            category = ActionCategory.ADVANCED
+        ),
+        ActionDefinition(
+            name = "WAIT",
+            description = """Pauses plan execution for a short duration. Use this right
+                after OPEN_APP (or any app-launch step) so the app finishes loading
+                before the next step tries to CLICK_TEXT/TYPE_TEXT into it — those
+                actions look for UI elements once and fail if the app is still
+                cold-starting. Capped at 10 seconds.""",
+            params = listOf(
+                ParamDefinition("durationMs", ParamType.INT, false, "Milliseconds to wait, max 10000", defaultValue = 2000)
+            ),
+            examples = listOf("wait 2 seconds", "wait for the app to load", "pause for a moment"),
+            category = ActionCategory.ADVANCED
+        ),
 
         // ── AGENT ───────────────────────────────────────
 

--- a/app/src/main/java/com/opendroid/ai/core/agent/AgentLoop.kt
+++ b/app/src/main/java/com/opendroid/ai/core/agent/AgentLoop.kt
@@ -14,8 +14,13 @@ import com.opendroid.ai.data.models.PlanStatus
 import com.opendroid.ai.data.models.PlanStep
 import com.opendroid.ai.data.models.StepStatus
 import com.opendroid.ai.data.repository.ConversationRepository
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -75,22 +80,96 @@ class AgentLoop @Inject constructor(
     private val json = Json { ignoreUnknownKeys = true; coerceInputValues = true; isLenient = true }
     private val queryMutex = Mutex()
 
-    @Volatile private var lastExecutedAction: String? = null
-    @Volatile private var lastExecutedParams: Map<String, String> = emptyMap()
+    // The currently in-flight processQuery/approveProposedPlan job, if any. Tracked so a
+    // fresh query (or an explicit cancel) can stop whatever the agent is doing right now.
+    // NOT reassigned when processQuery is merely delivering a reply to a pending
+    // awaitUserResponse() prompt - that reply belongs to the job already running.
+    @Volatile private var currentJob: Job? = null
+
+    // The session id pinned for whichever task currentJob is currently running end-to-end.
+    // Resolved ONCE, right when a genuinely new task starts (processQuery for a fresh query,
+    // or approveProposedPlan), then threaded as a plain parameter through that task's whole
+    // call chain, so every message the task writes - plan execution, contact-picker prompts,
+    // the final summary - uses that same id and never re-resolves "current session" mid-task.
+    // If the user switches (or starts) a chat while the task is still running, its writes
+    // keep landing in the chat it was pinned to, not wherever the user has navigated to.
+    //
+    // That parameter-threading is what makes pinning safe against races: this field is only
+    // ever read back in one place - relaying a reply to THIS SAME task's awaitUserResponse()
+    // prompt (see processQuery) - never by the task's own ongoing execution, so a later task
+    // overwriting this field can't redirect an earlier task's still-unwinding writes.
+    @Volatile private var activeTaskSessionId: String = ""
+
+    // The last successfully executed action/params, scoped PER SESSION so a contextual
+    // follow-up (AliasResolver.resolveContextual - "turn it off", "stop it", ...) in one
+    // chat can only ever resolve against that same chat's own history, never leftover
+    // state from an unrelated conversation. Previously this was a pair of process-global
+    // @Volatile fields, which meant a device toggle executed in chat A would silently be
+    // replayed by a generic contextual phrase typed in chat B. Bundled into one data class
+    // per session (rather than two parallel maps) so an action and its params can never be
+    // read back mismatched.
+    private data class LastExecutedAction(val action: String, val params: Map<String, String>)
+    private val lastExecutedActionsBySession = java.util.concurrent.ConcurrentHashMap<String, LastExecutedAction>()
+
+    // Session id the currently PlanProposed plan (if any) was proposed in, or null when
+    // agentState isn't PlanProposed. planManager.currentPlan and agentState are both
+    // single global values with no session affiliation of their own, so this is what lets
+    // a genuinely new task starting in a DIFFERENT session (see resolveStaleProposedPlan)
+    // recognize "there's a proposal out there that isn't mine" before it does anything
+    // that would otherwise silently clobber it.
+    @Volatile private var proposedPlanSessionId: String? = null
 
     private val _agentState = MutableStateFlow<AgentState>(AgentState.Idle)
     val agentState: StateFlow<AgentState> = _agentState.asStateFlow()
 
-    private val _userInputFlow = kotlinx.coroutines.flow.MutableSharedFlow<String>(extraBufferCapacity = 1)
-    var isWaitingForUserInput: Boolean = false
-        private set
+    // A single pending awaitUserResponse() prompt, identified by [requestId] - not just a
+    // session id, so that even a second prompt opened for the SAME session can never be
+    // resolved by a reply aimed at an earlier, already-abandoned one. [deferred] is
+    // completed exactly once, by the reply path in processQuery, and ONLY if it is still
+    // the value installed here (re-validated at completion time, not just when the reply
+    // was scheduled) - there is deliberately no buffering flow a stale reply could sit in
+    // and later be picked up by some unrelated future prompt. See processQuery.
+    private data class PendingUserInput(
+        val sessionId: String,
+        val requestId: String,
+        val deferred: CompletableDeferred<String>
+    )
 
-    suspend fun awaitUserResponse(): String {
-        isWaitingForUserInput = true
+    @Volatile private var pendingUserInput: PendingUserInput? = null
+
+    // Session id of whichever task is currently parked inside awaitUserResponse(), or null
+    // when nothing is waiting. Session-affiliated (not a bare boolean) so processQuery can
+    // tell a genuine reply to THIS prompt (arriving from the same session) apart from an
+    // unrelated new message that happens to arrive in some other chat while this prompt is
+    // still open - see processQuery.
+    @Volatile private var waitingSessionId: String? = null
+
+    val isWaitingForUserInput: Boolean
+        get() = waitingSessionId != null
+
+    /**
+     * Suspends until the user answers a prompt this task just posted. Defaults to
+     * whichever session the currently running task is pinned to (activeTaskSessionId) -
+     * correct for every existing internal caller, since a call to this function only ever
+     * happens from within that task's own execution. Pass a session explicitly only if
+     * that assumption doesn't hold.
+     */
+    suspend fun awaitUserResponse(sessionId: String = activeTaskSessionId): String {
+        val request = PendingUserInput(sessionId, UUID.randomUUID().toString(), CompletableDeferred())
+        waitingSessionId = sessionId
+        pendingUserInput = request
         try {
-            return _userInputFlow.first()
+            return request.deferred.await()
         } finally {
-            isWaitingForUserInput = false
+            // Only clear state that is still ours - a newer prompt for the same (or a
+            // different) session, or an explicit abandon/cancel, may already have
+            // replaced or cleared it, and clobbering that would be wrong.
+            if (pendingUserInput === request) {
+                pendingUserInput = null
+            }
+            if (waitingSessionId == sessionId) {
+                waitingSessionId = null
+            }
         }
     }
 
@@ -101,9 +180,68 @@ class AgentLoop @Inject constructor(
     // Speak callback to be implemented by TTS service
     var onSpeakCallback: ((String) -> Unit)? = null
 
-    fun processQuery(query: String, context: Context) {
-        scope.launch {
+    /**
+     * @param explicitSessionId The session this message actually belongs to (whatever chat
+     * the caller was looking at when the user hit send), if the caller can determine it.
+     * Used to decide whether this message answers a pending awaitUserResponse() prompt -
+     * see below - and, for a genuinely new query, which session it's stored in. Callers
+     * that cannot determine this (e.g. voice input via OpenDroidService, which has no
+     * notion of "which chat" a spoken query belongs to) pass null, which preserves the
+     * pre-multi-session behavior: a null session is always assumed to answer whatever
+     * prompt is currently pending, and otherwise falls back to resolving "current".
+     */
+    fun processQuery(query: String, context: Context, explicitSessionId: String? = null) {
+        // processQuery is also the delivery path for a reply to a pending
+        // awaitUserResponse() prompt (see below). That's ONLY true when this message comes
+        // from the SAME session the waiting task is pinned to (waitingSessionId) - a
+        // message from a different session is a genuinely new query, never an answer to
+        // some other chat's prompt, no matter how it compares to the global "is anything
+        // waiting" state.
+        val waitingSession = waitingSessionId
+        // Snapshot of the exact prompt that is pending right now, at the moment this
+        // reply was scheduled. The reply is only ever allowed to resolve THIS SAME
+        // instance - re-checked below, inside the launched coroutine, right before
+        // completing it - never whatever happens to be pending by the time that
+        // coroutine actually runs.
+        val pendingAtScheduleTime = pendingUserInput
+        val isAnsweringPendingQuestion = waitingSession != null &&
+                (explicitSessionId == null || explicitSessionId == waitingSession)
+
+        if (waitingSession != null && !isAnsweringPendingQuestion) {
+            // A brand-new message arrived in a different session while another task is
+            // still parked on a prompt in `waitingSession`. Nobody there is ever going to
+            // answer that prompt now - kill it and leave a short, honest message in ITS OWN
+            // session saying it stopped waiting, rather than either routing this message
+            // into the wrong chat or leaving that chat hanging silently forever.
+            abandonWaitingTask(waitingSession)
+        } else if (!isAnsweringPendingQuestion) {
+            currentJob?.cancel()
+        }
+
+        val job = scope.launch {
             try {
+                // Pin the session THIS task writes to, resolved once, right here, before any
+                // message is written. A genuinely new query pins whatever session the caller
+                // says this message belongs to (falling back to whatever is current if the
+                // caller couldn't say); a reply to a pending prompt reuses the session the
+                // task it's replying to already pinned via activeTaskSessionId - it must NOT
+                // re-resolve "current", since the user may have switched (or created) chats
+                // while that task was still waiting on them.
+                val sessionId = if (isAnsweringPendingQuestion) {
+                    activeTaskSessionId
+                } else {
+                    (explicitSessionId ?: conversationRepository.ensureCurrentSessionId())
+                        .also { activeTaskSessionId = it }
+                }
+
+                if (!isAnsweringPendingQuestion) {
+                    // This is a genuinely new task. If some OTHER session still has an
+                    // unresolved plan proposal sitting in agentState/planManager, resolve
+                    // it explicitly right now, before anything below can silently
+                    // overwrite it out from under that chat - see resolveStaleProposedPlan.
+                    resolveStaleProposedPlan(sessionId)
+                }
+
                 // Only capture the screen when the query actually asks about it.
                 // Attaching a screenshot to every request would silently send
                 // whatever is on screen (messages, banking apps, ...) to the LLM.
@@ -121,25 +259,39 @@ class AgentLoop @Inject constructor(
                     modelBadge = null,
                     imageBase64 = screenshotBase64
                 )
-                memoryManager.storeMessage(userMsg)
-                conversationRepository.insertMessage(userMsg)
+                memoryManager.storeMessage(userMsg, sessionId)
+                conversationRepository.insertMessage(sessionId, userMsg)
 
-                if (isWaitingForUserInput) {
-                    _userInputFlow.emit(query)
+                if (isAnsweringPendingQuestion) {
+                    // Re-validate at delivery time, not just at schedule time: only
+                    // complete the EXACT prompt this reply was aimed at (matched by
+                    // requestId, not merely by session). If it's gone - already answered,
+                    // abandoned, or superseded by a newer prompt in the meantime - there
+                    // is nothing to buffer it for; just drop it.
+                    val pending = pendingUserInput
+                    if (pending != null && pending.requestId == pendingAtScheduleTime?.requestId) {
+                        pending.deferred.complete(query)
+                    }
                     return@launch
                 }
 
                 // Serialize query handling so contextual follow-up state cannot race.
                 queryMutex.withLock {
-                    processQueryLocked(userMsg, query, context)
+                    processQueryLocked(userMsg, query, context, sessionId)
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 _agentState.value = AgentState.Error(e.localizedMessage ?: "Unknown processing error")
             }
         }
+
+        if (!isAnsweringPendingQuestion) {
+            currentJob = job
+        }
     }
 
-    private suspend fun processQueryLocked(userMsg: ChatMessage, query: String, context: Context) {
+    private suspend fun processQueryLocked(userMsg: ChatMessage, query: String, context: Context, sessionId: String) {
                 _agentState.value = AgentState.Thinking
 
                 // 0. Check if this is a complex, multi-step query
@@ -149,15 +301,16 @@ class AgentLoop @Inject constructor(
 
                 // 1. Alias resolution — bypass LLM for simple, single-action commands ONLY
                 if (!isMultiStep) {
-                    val contextual = AliasResolver.resolveContextual(query, lastExecutedAction, lastExecutedParams)
+                    val lastExecuted = lastExecutedActionsBySession[sessionId]
+                    val contextual = AliasResolver.resolveContextual(query, lastExecuted?.action, lastExecuted?.params)
                     if (contextual != null) {
-                        executeAliasDirect(contextual, query, context)
+                        executeAliasDirect(contextual, query, context, sessionId)
                         return
                     }
 
                     val alias = AliasResolver.resolve(query)
                     if (alias != null) {
-                        executeAliasDirect(alias, query, context)
+                        executeAliasDirect(alias, query, context, sessionId)
                         return
                     }
 
@@ -169,7 +322,7 @@ class AgentLoop @Inject constructor(
                                 "SET_ALARM",
                                 mapOf("time" to timeStr, "label" to "Alarm")
                             )
-                            executeAliasDirect(alarmHint, query, context)
+                            executeAliasDirect(alarmHint, query, context, sessionId)
                             return
                         }
                     }
@@ -182,7 +335,7 @@ class AgentLoop @Inject constructor(
                                 "SET_TIMER",
                                 mapOf("duration" to durationSecs.toString(), "label" to "Timer")
                             )
-                            executeAliasDirect(timerHint, query, context)
+                            executeAliasDirect(timerHint, query, context, sessionId)
                             return
                         }
                     }
@@ -191,9 +344,9 @@ class AgentLoop @Inject constructor(
                 // 2. Intent Classification
                 val requiresAction = intentClassifier.requiresAction(query)
                 if (requiresAction) {
-                    generatePlan(userMsg, context)
+                    generatePlan(userMsg, context, sessionId)
                 } else {
-                    executeSimpleQuery(userMsg)
+                    executeSimpleQuery(userMsg, sessionId)
                 }
     }
 
@@ -204,7 +357,8 @@ class AgentLoop @Inject constructor(
     private suspend fun executeAliasDirect(
         alias: AliasResolver.ActionHint,
         originalQuery: String,
-        context: Context
+        context: Context,
+        sessionId: String
     ) {
         try {
             val speechText = humanizePreSpeech(alias.action)
@@ -217,24 +371,26 @@ class AgentLoop @Inject constructor(
                 sender = ChatMessage.Sender.AGENT,
                 modelBadge = "alias"
             )
-            conversationRepository.insertMessage(replyMsg)
-            memoryManager.storeMessage(replyMsg)
+            conversationRepository.insertMessage(sessionId, replyMsg)
+            memoryManager.storeMessage(replyMsg, sessionId)
 
             // Build a single-step plan from the alias
             val plan = buildSingleStepPlan(originalQuery, alias.action, alias.baseParams)
 
             planManager.startNewPlan(plan, context)
-            executePlanLoop(plan, context)
+            executePlanLoop(plan, context, sessionId)
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             _agentState.value = AgentState.Error("Alias execution failed: ${e.localizedMessage}")
         }
     }
 
-    private suspend fun executeSimpleQuery(userMsg: ChatMessage) {
+    private suspend fun executeSimpleQuery(userMsg: ChatMessage, sessionId: String) {
         try {
             val provider = llmProviderFactory.getActiveProvider()
             val relevantContext = memoryManager.getRelevantContext(userMsg.text)
-            
+
             val systemPrompt = """
                 You are OpenDroid, a friendly and helpful Android AI assistant.
                 Talk like a real person — warm, casual, and natural. Avoid sounding robotic.
@@ -248,7 +404,7 @@ class AgentLoop @Inject constructor(
                 $relevantContext
             """.trimIndent()
 
-            val lastMsgs = conversationRepository.getLastMessages(10).map { msg ->
+            val lastMsgs = conversationRepository.getLastMessages(sessionId, 10).map { msg ->
                 if (msg.id == userMsg.id) {
                     msg.copy(imageBase64 = userMsg.imageBase64)
                 } else {
@@ -264,7 +420,7 @@ class AgentLoop @Inject constructor(
                 sender = ChatMessage.Sender.AGENT,
                 modelBadge = provider.name
             )
-            conversationRepository.insertMessage(replyMsg)
+            conversationRepository.insertMessage(sessionId, replyMsg)
 
             try {
                 provider.streamComplete(
@@ -277,8 +433,10 @@ class AgentLoop @Inject constructor(
                     )
                 ).collect { chunk ->
                     currentReplyText += chunk
-                    conversationRepository.insertMessage(replyMsg.copy(text = currentReplyText))
+                    conversationRepository.insertMessage(sessionId, replyMsg.copy(text = currentReplyText))
                 }
+            } catch (streamError: CancellationException) {
+                throw streamError
             } catch (streamError: Exception) {
                 if (currentReplyText.isEmpty()) {
                     val response = provider.complete(
@@ -291,21 +449,23 @@ class AgentLoop @Inject constructor(
                         )
                     )
                     currentReplyText = response.content.trim()
-                    conversationRepository.insertMessage(replyMsg.copy(text = currentReplyText))
+                    conversationRepository.insertMessage(sessionId, replyMsg.copy(text = currentReplyText))
                 }
             }
 
             val finalReplyMsg = replyMsg.copy(text = formatStreamedReply(currentReplyText))
-            conversationRepository.insertMessage(finalReplyMsg)
-            memoryManager.storeMessage(finalReplyMsg)
+            conversationRepository.insertMessage(sessionId, finalReplyMsg)
+            memoryManager.storeMessage(finalReplyMsg, sessionId)
             _agentState.value = AgentState.Speaking(finalReplyMsg.text)
             onSpeakCallback?.invoke(finalReplyMsg.text)
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             _agentState.value = AgentState.Error(NetworkErrorFormatter.toUserMessage(e))
         }
     }
 
-    private suspend fun generatePlan(userMsg: ChatMessage, context: Context) {
+    private suspend fun generatePlan(userMsg: ChatMessage, context: Context, sessionId: String) {
         try {
             val provider = llmProviderFactory.getActiveProvider()
             val relevantContext = memoryManager.getRelevantContext(userMsg.text)
@@ -383,12 +543,15 @@ class AgentLoop @Inject constructor(
 
             planManager.startNewPlan(plan, context)
             if (config.autoConfirmPlans) {
-                executePlanLoop(plan, context)
+                executePlanLoop(plan, context, sessionId)
             } else {
+                proposedPlanSessionId = sessionId
                 _agentState.value = AgentState.PlanProposed(plan)
             }
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
-            fallbackOrError(userMsg, context, e)
+            fallbackOrError(userMsg, context, e, sessionId)
         }
     }
 
@@ -396,13 +559,14 @@ class AgentLoop @Inject constructor(
      * Treat malformed plan JSON as an actionable planning failure. Other provider
      * failures can still degrade to a normal chat response.
      */
-    private suspend fun fallbackOrError(userMsg: ChatMessage, context: Context, cause: Throwable) {
+    private suspend fun fallbackOrError(userMsg: ChatMessage, context: Context, cause: Throwable, sessionId: String) {
         android.util.Log.e("AgentLoop", "Plan generation failed: ${cause.localizedMessage}", cause)
 
+        val lastExecuted = lastExecutedActionsBySession[sessionId]
         val alias = AliasResolver.resolve(userMsg.text)
-            ?: AliasResolver.resolveContextual(userMsg.text, lastExecutedAction, lastExecutedParams)
+            ?: AliasResolver.resolveContextual(userMsg.text, lastExecuted?.action, lastExecuted?.params)
         if (alias != null) {
-            executeAliasDirect(alias, userMsg.text, context)
+            executeAliasDirect(alias, userMsg.text, context, sessionId)
             return
         }
 
@@ -417,50 +581,202 @@ class AgentLoop @Inject constructor(
                 resultData = null,
                 errorMessage = cause.localizedMessage
             )
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             android.util.Log.e("AgentLoop", "Failed to log plan generation failure: ${e.localizedMessage}")
         }
-        executeSimpleQuery(userMsg)
+        executeSimpleQuery(userMsg, sessionId)
     }
 
     fun approveProposedPlan(context: Context) {
-        scope.launch {
+        currentJob?.cancel()
+        val job = scope.launch {
+            // Approving a proposed plan starts a new task in its own right (the plan may
+            // have been proposed in an earlier, now-idle turn), so pin its session here too -
+            // same rationale as processQuery, see activeTaskSessionId. Executes in the
+            // session the plan was actually PROPOSED for, never wherever the user happens
+            // to be looking right now - falls back to "current" only if somehow nothing
+            // was pinned (there is no proposal to misattribute in that case anyway).
+            val sessionId = (proposedPlanSessionId ?: conversationRepository.ensureCurrentSessionId())
+                .also { activeTaskSessionId = it }
+            proposedPlanSessionId = null
             queryMutex.withLock {
                 val plan = planManager.currentPlan.value ?: return@withLock
-                executePlanLoop(plan, context)
+                executePlanLoop(plan, context, sessionId)
             }
         }
+        currentJob = job
     }
 
     fun rejectProposedPlan() {
+        proposedPlanSessionId = null
         planManager.clearPlan()
         _agentState.value = AgentState.Idle
     }
 
-    private suspend fun executePlanLoop(plan: Plan, context: Context) {
+    /**
+     * Forgets a session's contextual follow-up state (see
+     * [lastExecutedActionsBySession]). Call this once a session is gone for good
+     * (ChatViewModel.deleteChat -> ConversationRepository.deleteSession) so its
+     * entry doesn't sit in the map forever - a deleted chat can never come back
+     * to ask "turn it off" against whatever it last did. Harmless no-op if the
+     * session never executed an action, or is already gone.
+     */
+    fun forgetSession(sessionId: String) {
+        lastExecutedActionsBySession.remove(sessionId)
+    }
+
+    /**
+     * Cancels whatever the agent is currently doing - a running plan, a query in
+     * flight, or a pending "waiting for user input" prompt - and returns the loop
+     * to Idle. Safe to call when nothing is running: when there is no job to
+     * cancel there is nothing in flight for planManager.cancelPlan() to affect
+     * either, so it's skipped entirely rather than invoked pointlessly - it would
+     * otherwise land on whatever plan is still sitting in PlanManager from the
+     * last finished task (kept there deliberately so the Plan tab can keep
+     * showing it - see PlanManager.updatePlanStatus) and relabel it, which is
+     * exactly what PlanManager's own terminal-status guard on cancelPlan() also
+     * defends against - see that doc comment for why that guard is the
+     * load-bearing one.
+     *
+     * The join-then-cancel below runs on its own coroutine, so it can finish
+     * arbitrarily later - potentially after a brand-new, unrelated task has
+     * already started (see the class-level race this guards against). It must
+     * NOT resolve "the plan to cancel" by asking PlanManager what's current at
+     * that later point; the only trustworthy identity is whatever plan was
+     * actually current RIGHT NOW, captured synchronously before [jobToCancel]
+     * even starts unwinding. [planManager.currentPlan] is a plain StateFlow
+     * read, not suspending, so this capture is safe to do here.
+     */
+    fun cancelCurrentTask() {
+        val jobToCancel = currentJob
+        currentJob = null
+        waitingSessionId = null
+        proposedPlanSessionId = null
+        _agentState.value = AgentState.Idle
+        jobToCancel?.cancel() ?: return
+        val planIdToCancel = planManager.currentPlan.value?.planId
+        scope.launch {
+            // Wait for the cancelled job to actually finish unwinding before marking
+            // the plan cancelled, so its own (best-effort) status writes can't race
+            // ahead of and overwrite the CANCELLED status set here.
+            jobToCancel.join()
+            if (planIdToCancel != null) {
+                planManager.cancelPlan(planIdToCancel)
+            }
+        }
+    }
+
+    /**
+     * Called right before a genuinely new task starts (see processQuery), never for a
+     * reply to a pending awaitUserResponse() prompt. If [newSessionId] is about to take
+     * over agentState/planManager's single global slots and some OTHER session still has
+     * a plan sitting in AgentState.PlanProposed - proposed, but never approved, rejected,
+     * or cancelled - resolve it explicitly right now instead of letting it be silently
+     * destroyed: cancel it in planManager and leave a short, honest message in ITS OWN
+     * session, mirroring the treatment abandonWaitingTask() gives an abandoned prompt.
+     * A no-op when there is nothing stale to resolve, or when the proposal already
+     * belongs to [newSessionId] (a new task in the SAME chat legitimately supersedes it).
+     */
+    private suspend fun resolveStaleProposedPlan(newSessionId: String) {
+        val staleSessionId = proposedPlanSessionId
+        if (staleSessionId == null || staleSessionId == newSessionId) return
+        val proposedState = _agentState.value as? AgentState.PlanProposed ?: return
+
+        proposedPlanSessionId = null
+        _agentState.value = AgentState.Idle
+        // Target the exact plan this state was carrying, not "whatever is
+        // current" - see cancelPlan's expectedPlanId doc comment. There is no
+        // job-join race here (the task that proposed this plan already
+        // finished), but pinning the identity explicitly keeps this call
+        // consistent with cancelCurrentTask/abandonWaitingTask rather than
+        // relying on a coincidence that nothing else changed it in between.
+        planManager.cancelPlan(proposedState.plan.planId)
+
+        val stoppedMsg = ChatMessage(
+            id = UUID.randomUUID().toString(),
+            text = "I cancelled the plan I proposed here since you started a new task elsewhere.",
+            sender = ChatMessage.Sender.AGENT,
+            modelBadge = "System"
+        )
+        conversationRepository.insertMessage(staleSessionId, stoppedMsg)
+        memoryManager.storeMessage(stoppedMsg, staleSessionId)
+    }
+
+    /**
+     * Cancels a task that is parked in awaitUserResponse() for [staleSessionId] because a
+     * genuinely new message just arrived in a different session - nobody in
+     * [staleSessionId] is ever going to answer that prompt now. Mirrors
+     * [cancelCurrentTask]'s join-then-cancel-plan ordering, and additionally leaves a
+     * short, honest message in the abandoned prompt's OWN session so that chat doesn't
+     * just sit there silently forever.
+     */
+    private fun abandonWaitingTask(staleSessionId: String) {
+        val jobToCancel = currentJob
+        currentJob = null
+        waitingSessionId = null
+        _agentState.value = AgentState.Idle
+        jobToCancel?.cancel()
+        // Same identity-pinning rationale as cancelCurrentTask: capture now,
+        // synchronously, before jobToCancel unwinds - never resolve "the plan
+        // to cancel" from whatever PlanManager holds once the join below
+        // finally completes.
+        val planIdToCancel = planManager.currentPlan.value?.planId
+        scope.launch {
+            jobToCancel?.join()
+            if (planIdToCancel != null) {
+                planManager.cancelPlan(planIdToCancel)
+            }
+
+            val stoppedMsg = ChatMessage(
+                id = UUID.randomUUID().toString(),
+                text = "I stopped waiting for your reply here since you started a new conversation elsewhere.",
+                sender = ChatMessage.Sender.AGENT,
+                modelBadge = "System"
+            )
+            conversationRepository.insertMessage(staleSessionId, stoppedMsg)
+            memoryManager.storeMessage(stoppedMsg, staleSessionId)
+        }
+    }
+
+    private suspend fun executePlanLoop(plan: Plan, context: Context, sessionId: String) {
         planManager.updatePlanStatus(PlanStatus.RUNNING)
         var currentPlanState = planManager.currentPlan.value ?: return
 
         while (true) {
+            // Cooperative cancellation checkpoint: ensures a cancelCurrentTask() call
+            // stops this loop promptly even on iterations that finish without ever
+            // hitting a suspending call that would otherwise surface the cancellation.
+            currentCoroutineContext().ensureActive()
+
             val nextStep = planManager.getActiveStep()
             if (nextStep == null) {
                 // If there are any failed steps, plan is failed. Otherwise, completed!
                 val hasFailed = currentPlanState.steps.any { it.status == StepStatus.FAILED }
                 if (hasFailed) {
                     planManager.updatePlanStatus(PlanStatus.FAILED)
-                    speakAndSaveSummary(currentPlanState, false)
+                    speakAndSaveSummary(currentPlanState, false, sessionId)
                 } else {
                     planManager.updatePlanStatus(PlanStatus.COMPLETED)
-                    speakAndSaveSummary(currentPlanState, true)
+                    speakAndSaveSummary(currentPlanState, true, sessionId)
                 }
                 break
             }
 
-            _agentState.value = AgentState.ExecutingPlan(nextStep.description)
             planManager.updateStepStatus(nextStep.stepId, StepStatus.RUNNING)
 
+            // Re-read the step's current description/action/params immediately before
+            // dispatching. getStepSnapshot takes the same mutex the Plan-tab editor's
+            // mutators (updateStepDescription / updateStepParams) hold, so this always
+            // observes whichever edit last committed to the DB - never the stale copy
+            // getActiveStep() handed back at the top of this loop iteration, which a
+            // concurrent edit landing in between would otherwise silently outrun.
+            val stepToExecute = planManager.getStepSnapshot(nextStep.stepId) ?: nextStep
+            _agentState.value = AgentState.ExecutingPlan(stepToExecute.description)
+
             // Resolve parameters from prior step results
-            val resolvedParams = nextStep.params.mapValues { (_, value) ->
+            val resolvedParams = stepToExecute.params.mapValues { (_, value) ->
                 var newValue = value
                 currentPlanState.steps.forEach { completedStep ->
                     if (completedStep.status == StepStatus.COMPLETED && completedStep.result != null) {
@@ -479,40 +795,43 @@ class AgentLoop @Inject constructor(
 
             // Execute the action dispatcher
             var actionResult = try {
-                var result = actionDispatcher.execute(nextStep.action, resolvedParams, context)
-                
-                resolveNeedsInput(result, nextStep.action, resolvedParams, context)
+                var result = actionDispatcher.execute(stepToExecute.action, resolvedParams, context)
+
+                resolveNeedsInput(result, stepToExecute.action, resolvedParams, context, sessionId)
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
-                android.util.Log.e("AgentLoop", "Exception executing action ${nextStep.action}: ${e.localizedMessage}", e)
+                android.util.Log.e("AgentLoop", "Exception executing action ${stepToExecute.action}: ${e.localizedMessage}", e)
                 ActionResult(false, null, e.localizedMessage ?: "Unknown execution error")
             }
 
             try {
                 memoryManager.logTaskExecution(
-                    stepId = nextStep.stepId,
+                    stepId = stepToExecute.stepId,
                     planId = currentPlanState.planId,
-                    description = nextStep.description,
-                    actionType = nextStep.action,
+                    description = stepToExecute.description,
+                    actionType = stepToExecute.action,
                     params = resolvedParams,
                     success = actionResult.success,
                     resultData = actionResult.data,
                     errorMessage = actionResult.error
                 )
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 android.util.Log.e("AgentLoop", "Failed to log task execution: ${e.localizedMessage}")
             }
 
             if (actionResult.success) {
-                lastExecutedAction = nextStep.action
-                lastExecutedParams = resolvedParams
+                lastExecutedActionsBySession[sessionId] = LastExecutedAction(stepToExecute.action, resolvedParams)
                 planManager.updateStepStatus(
-                    nextStep.stepId,
+                    stepToExecute.stepId,
                     StepStatus.COMPLETED,
                     result = actionResult.data ?: "Completed successfully."
                 )
             } else if (actionResult is ActionResult.UnknownAction) {
                 planManager.updateStepStatus(
-                    nextStep.stepId,
+                    stepToExecute.stepId,
                     StepStatus.FAILED,
                     error = actionResult.error ?: "Action execution failed."
                 )
@@ -521,7 +840,7 @@ class AgentLoop @Inject constructor(
                 currentPlanState = planManager.currentPlan.value ?: break
 
                 // Trigger learning extraction
-                reEvalEngine.get().extractLearning(nextStep.action, currentPlanState.goal)
+                reEvalEngine.get().extractLearning(stepToExecute.action, currentPlanState.goal)
 
                 // Trigger silent replanning
                 val completed = currentPlanState.steps.filter { it.status == StepStatus.COMPLETED }
@@ -529,7 +848,7 @@ class AgentLoop @Inject constructor(
 
                 val replan = reEvalEngine.get().replanAfterUnknownAction(
                     originalGoal = currentPlanState.goal,
-                    failedStep = nextStep,
+                    failedStep = stepToExecute,
                     completedSteps = completed,
                     remainingSteps = remaining,
                     planId = currentPlanState.planId
@@ -542,7 +861,7 @@ class AgentLoop @Inject constructor(
                 when (replan.decision.uppercase()) {
                     "ABANDON" -> {
                         planManager.updatePlanStatus(PlanStatus.FAILED)
-                        speakAndSaveSummary(currentPlanState, false)
+                        speakAndSaveSummary(currentPlanState, false, sessionId)
                         return
                     }
                     "MODIFY" -> {
@@ -556,7 +875,7 @@ class AgentLoop @Inject constructor(
                     }
                     else -> {
                         planManager.updatePlanStatus(PlanStatus.FAILED)
-                        speakAndSaveSummary(currentPlanState, false)
+                        speakAndSaveSummary(currentPlanState, false, sessionId)
                         return
                     }
                 }
@@ -566,28 +885,30 @@ class AgentLoop @Inject constructor(
                 continue
             } else {
                 // Try fallback action
-                if (nextStep.fallback.isNotEmpty() && actionDispatcher.hasAction(nextStep.fallback)) {
+                if (stepToExecute.fallback.isNotEmpty() && actionDispatcher.hasAction(stepToExecute.fallback)) {
                     val fallbackResult = try {
-                        actionDispatcher.execute(nextStep.fallback, resolvedParams, context)
+                        actionDispatcher.execute(stepToExecute.fallback, resolvedParams, context)
+                    } catch (e: CancellationException) {
+                        throw e
                     } catch (e: Exception) {
                         ActionResult(false, null, e.localizedMessage ?: "Unknown execution error")
                     }
                     if (fallbackResult.success) {
                         planManager.updateStepStatus(
-                            nextStep.stepId,
+                            stepToExecute.stepId,
                             StepStatus.COMPLETED,
                             result = "Primary failed: ${actionResult.error}. Fallback execution succeeded: ${fallbackResult.data}"
                         )
                     } else {
                         planManager.updateStepStatus(
-                            nextStep.stepId,
+                            stepToExecute.stepId,
                             StepStatus.FAILED,
                             error = "Primary failed: ${actionResult.error}. Fallback failed: ${fallbackResult.error}"
                         )
                     }
                 } else {
                     planManager.updateStepStatus(
-                        nextStep.stepId,
+                        stepToExecute.stepId,
                         StepStatus.FAILED,
                         error = actionResult.error ?: "Action execution failed."
                     )
@@ -622,7 +943,7 @@ class AgentLoop @Inject constructor(
             when (reEval.decision.uppercase()) {
                 "ABANDON" -> {
                     planManager.updatePlanStatus(PlanStatus.FAILED)
-                    speakAndSaveSummary(currentPlanState, false)
+                    speakAndSaveSummary(currentPlanState, false, sessionId)
                     return
                 }
                 "MODIFY" -> {
@@ -664,7 +985,8 @@ class AgentLoop @Inject constructor(
         initialResult: ActionResult,
         actionName: String,
         initialParams: Map<String, String>,
-        context: Context
+        context: Context,
+        sessionId: String
     ): ActionResult {
         var result = initialResult
         var params = initialParams
@@ -672,9 +994,9 @@ class AgentLoop @Inject constructor(
         repeat(MAX_NEEDS_INPUT_PROMPTS) {
             val needsInput = result as? ActionResult.NeedsInput ?: return result
             val retry = if (needsInput.metadata["type"] == "contact_picker") {
-                handleContactPicker(needsInput, actionName, params, context)
+                handleContactPicker(needsInput, actionName, params, context, sessionId)
             } else {
-                handleNeedsInput(needsInput, actionName, params, context)
+                handleNeedsInput(needsInput, actionName, params, context, sessionId)
             }
             result = retry.result
             params = retry.params
@@ -694,7 +1016,8 @@ class AgentLoop @Inject constructor(
         pickerResult: ActionResult.NeedsInput,
         actionName: String,
         originalParams: Map<String, String>,
-        context: Context
+        context: Context,
+        sessionId: String
     ): NeedsInputRetry {
         val meta = pickerResult.metadata
         val matchesJson = meta["matches"] ?: return NeedsInputRetry(pickerResult, originalParams)
@@ -720,11 +1043,11 @@ class AgentLoop @Inject constructor(
             modelBadge = "System",
             contactPickerData = matchesJson
         )
-        conversationRepository.insertMessage(pickerMsg)
+        conversationRepository.insertMessage(sessionId, pickerMsg)
         onSpeakCallback?.invoke(pickerResult.question)
 
         // Wait for user response
-        val userSelection = awaitUserResponse()
+        val userSelection = awaitUserResponse(sessionId)
 
         // Save user's response as a chat message
         val userPickMsg = ChatMessage(
@@ -732,7 +1055,7 @@ class AgentLoop @Inject constructor(
             text = userSelection,
             sender = ChatMessage.Sender.USER
         )
-        conversationRepository.insertMessage(userPickMsg)
+        conversationRepository.insertMessage(sessionId, userPickMsg)
 
         // Resolve user selection to a contact
         val selectedContact = when {
@@ -767,7 +1090,7 @@ class AgentLoop @Inject constructor(
                 sender = ChatMessage.Sender.AGENT,
                 modelBadge = "System"
             )
-            conversationRepository.insertMessage(failMsg)
+            conversationRepository.insertMessage(sessionId, failMsg)
             return NeedsInputRetry(
                 ActionResult.Failure(
                     errorMsg = "Contact selection not understood",
@@ -799,7 +1122,7 @@ class AgentLoop @Inject constructor(
             sender = ChatMessage.Sender.AGENT,
             modelBadge = "System"
         )
-        conversationRepository.insertMessage(confirmMsg)
+        conversationRepository.insertMessage(sessionId, confirmMsg)
 
         // Re-execute the original action with resolved contact
         val resolvedParams = originalParams.toMutableMap()
@@ -822,7 +1145,8 @@ class AgentLoop @Inject constructor(
         needsInput: ActionResult.NeedsInput,
         actionName: String,
         originalParams: Map<String, String>,
-        context: Context
+        context: Context,
+        sessionId: String
     ): NeedsInputRetry {
         val optionsText = if (needsInput.options.isNotEmpty()) {
             "\n\n" + needsInput.options.joinToString("\n") { "- $it" }
@@ -835,10 +1159,10 @@ class AgentLoop @Inject constructor(
             sender = ChatMessage.Sender.AGENT,
             modelBadge = "System"
         )
-        conversationRepository.insertMessage(promptMsg)
+        conversationRepository.insertMessage(sessionId, promptMsg)
         onSpeakCallback?.invoke(needsInput.question)
 
-        val answer = awaitUserResponse().trim()
+        val answer = awaitUserResponse(sessionId).trim()
         if (answer.isEmpty()) {
             return NeedsInputRetry(
                 ActionResult.Failure(
@@ -854,7 +1178,7 @@ class AgentLoop @Inject constructor(
             text = answer,
             sender = ChatMessage.Sender.USER
         )
-        conversationRepository.insertMessage(userEcho)
+        conversationRepository.insertMessage(sessionId, userEcho)
 
         val paramKey = paramKeyForNeedsInput(needsInput, actionName)
         val newParams = originalParams.toMutableMap().apply { put(paramKey, answer) }
@@ -864,7 +1188,7 @@ class AgentLoop @Inject constructor(
         )
     }
 
-    private suspend fun speakAndSaveSummary(plan: Plan, isSuccess: Boolean) {
+    private suspend fun speakAndSaveSummary(plan: Plan, isSuccess: Boolean, sessionId: String) {
         val summaryText = if (isSuccess) {
             // Build a natural, human-sounding summary from step results
             val stepSummaries = plan.steps
@@ -911,8 +1235,8 @@ class AgentLoop @Inject constructor(
             sender = ChatMessage.Sender.AGENT,
             modelBadge = "System"
         )
-        memoryManager.storeMessage(assistantMsg)
-        conversationRepository.insertMessage(assistantMsg)
+        memoryManager.storeMessage(assistantMsg, sessionId)
+        conversationRepository.insertMessage(sessionId, assistantMsg)
 
         _agentState.value = AgentState.Speaking(summaryText)
         onSpeakCallback?.invoke(summaryText)

--- a/app/src/main/java/com/opendroid/ai/core/agent/AliasResolver.kt
+++ b/app/src/main/java/com/opendroid/ai/core/agent/AliasResolver.kt
@@ -243,6 +243,35 @@ object AliasResolver {
     }
 
     /**
+     * Matches "open youtube and search/play/watch X", "youtube search/play/watch X",
+     * and "search/play/watch X on youtube" style phrasings, capturing X as the query.
+     * These read as compound (an "and" with an action verb on both sides) but are
+     * really a single PLAY_YOUTUBE call — see [extractYoutubeQuery].
+     */
+    private val youtubeQueryPatterns = listOf(
+        Regex("""^open\s+youtube\s+and\s+(?:search(?:\s+for)?|play|watch)\s+(.+)$"""),
+        Regex("""^youtube\s+(?:search(?:\s+for)?|play|watch)\s+(.+)$"""),
+        Regex("""^(?:search|play|watch)\s+(.+?)\s+on\s+youtube$""")
+    )
+
+    /**
+     * Extracts the search query from a "open youtube and search cat videos",
+     * "youtube search lofi", "search cat videos on youtube" style phrasing.
+     * Returns null when the input doesn't match one of these YouTube phrasings —
+     * in particular a bare "youtube" or "open youtube" (no query) always returns
+     * null so those keep falling through to their existing behavior.
+     */
+    fun extractYoutubeQuery(input: String): String? {
+        val cleaned = cleanInput(input)
+        for (regex in youtubeQueryPatterns) {
+            val match = regex.find(cleaned) ?: continue
+            val query = match.groupValues[1].trim()
+            if (query.isNotEmpty()) return query
+        }
+        return null
+    }
+
+    /**
      * Resolve user input to an ActionHint.
      * Returns null if no alias matches.
      */
@@ -253,6 +282,14 @@ object AliasResolver {
         // 1. Exact match (always wins)
         aliases[cleaned]?.let { return it }
         aliases[lower]?.let { return it }
+
+        // 1b. YouTube search/play/watch extraction — routes straight to the working
+        //     single-shot PLAY_YOUTUBE action instead of the compound-intent guard
+        //     below (which would otherwise swallow this because it contains "search"
+        //     or "play") or the LLM planner's broken OPEN_APP + CLICK_TEXT/TYPE_TEXT plan.
+        extractYoutubeQuery(input)?.let { query ->
+            return ActionHint("PLAY_YOUTUBE", mapOf("query" to query))
+        }
 
         // 2. Dynamic brightness extraction — "set brightness to 30%", "brightness 60", etc.
         //    This runs BEFORE compound-intent guard so the LLM doesn't need to handle it.

--- a/app/src/main/java/com/opendroid/ai/core/agent/IntentClassifier.kt
+++ b/app/src/main/java/com/opendroid/ai/core/agent/IntentClassifier.kt
@@ -85,6 +85,17 @@ class IntentClassifier @Inject constructor(
     fun classifyComplexity(query: String): QueryComplexity {
         val lowercaseQuery = query.lowercase()
 
+        // ── Fast-path: "open youtube and search X" / "youtube search X" /
+        //    "search X on youtube" style phrasings. These LOOK compound (an "and"
+        //    with an action verb on both sides, e.g. "open" + "search") and would
+        //    otherwise fall through to the LLM planner, which has no way to wait for
+        //    YouTube to cold-start or submit a typed search. AliasResolver resolves
+        //    the exact same phrasing straight to the working single-shot PLAY_YOUTUBE
+        //    action, so this must be checked BEFORE the compound-indicator check below.
+        if (AliasResolver.extractYoutubeQuery(lowercaseQuery) != null) {
+            return QueryComplexity.SIMPLE
+        }
+
         // Check for compound indicators FIRST — these always indicate multi-step tasks
         val compoundIndicators = listOf(
             " and then ", " then ", " after that ", " after ",

--- a/app/src/main/java/com/opendroid/ai/core/agent/PlanManager.kt
+++ b/app/src/main/java/com/opendroid/ai/core/agent/PlanManager.kt
@@ -7,9 +7,14 @@ import com.opendroid.ai.data.models.PlanStatus
 import com.opendroid.ai.data.models.PlanStep
 import com.opendroid.ai.data.models.StepStatus
 import com.opendroid.ai.data.repository.PlanRepository
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -22,62 +27,262 @@ class PlanManager @Inject constructor(
     private val _currentPlan = MutableStateFlow<Plan?>(null)
     val currentPlan: StateFlow<Plan?> = _currentPlan.asStateFlow()
 
+    /**
+     * Guards every read-modify-write of [_currentPlan]. There are now two
+     * independent writers - AgentLoop's executePlanLoop coroutine driving
+     * execution, and the Plan tab editor mutating pending steps from the UI
+     * - and every mutator below reads `_currentPlan.value`, derives a new
+     * Plan from it, and writes the result back. Without a lock held across
+     * that whole read+write, two concurrent mutators can both read the same
+     * stale snapshot and the later write silently discards the other (e.g.
+     * a step that just finished reverting to RUNNING because a concurrent
+     * param edit was computed from the pre-completion snapshot).
+     */
+    private val mutex = Mutex()
+
+    /**
+     * Used only by [clearPlan]. That function must stay non-suspend because
+     * it is invoked synchronously from AgentLoop.rejectProposedPlan() (not a
+     * suspend function), so it can't take [mutex] with `withLock` directly
+     * on the caller's thread. clearPlan() has nothing to compute from the
+     * previous value - it unconditionally nulls the plan - so it hops onto
+     * this scope to acquire the mutex before writing, which keeps it
+     * serialized with every other mutator instead of racing them with an
+     * unguarded assignment.
+     */
+    private val scope = CoroutineScope(Dispatchers.Default)
+
     suspend fun startNewPlan(plan: Plan, context: Context) {
         val validatedPlan = planValidator.get().validateAndFix(plan, context)
-        val runningPlan = validatedPlan.copy(status = PlanStatus.RUNNING)
-        _currentPlan.value = runningPlan
-        workingMemory.activePlan = runningPlan
-        saveCurrentPlan()
+        mutex.withLock {
+            val runningPlan = validatedPlan.copy(status = PlanStatus.RUNNING)
+            _currentPlan.value = runningPlan
+            workingMemory.activePlan = runningPlan
+            saveCurrentPlanLocked()
+        }
     }
 
     suspend fun updateStepStatus(stepId: String, status: StepStatus, result: String? = null, error: String? = null) {
-        val plan = _currentPlan.value ?: return
-        val updatedSteps = plan.steps.map { step ->
-            if (step.stepId == stepId) {
-                step.copy(status = status, result = result, error = error)
-            } else {
-                step
+        mutex.withLock {
+            val plan = _currentPlan.value ?: return@withLock
+            val updatedSteps = plan.steps.map { step ->
+                if (step.stepId == stepId) {
+                    step.copy(status = status, result = result, error = error)
+                } else {
+                    step
+                }
             }
+            val updatedPlan = plan.copy(steps = updatedSteps)
+            _currentPlan.value = updatedPlan
+            workingMemory.activePlan = updatedPlan
+            saveCurrentPlanLocked()
         }
-        val updatedPlan = plan.copy(steps = updatedSteps)
-        _currentPlan.value = updatedPlan
-        workingMemory.activePlan = updatedPlan
-        saveCurrentPlan()
     }
 
     suspend fun updatePlanStatus(status: PlanStatus) {
-        val plan = _currentPlan.value ?: return
-        val updatedPlan = plan.copy(status = status)
-        _currentPlan.value = updatedPlan
-        if (status == PlanStatus.COMPLETED || status == PlanStatus.FAILED) {
-            workingMemory.activePlan = null
-        } else {
-            workingMemory.activePlan = updatedPlan
+        mutex.withLock {
+            val plan = _currentPlan.value ?: return@withLock
+            val updatedPlan = plan.copy(status = status)
+            _currentPlan.value = updatedPlan
+            if (status == PlanStatus.COMPLETED || status == PlanStatus.FAILED) {
+                workingMemory.activePlan = null
+            } else {
+                workingMemory.activePlan = updatedPlan
+            }
+            saveCurrentPlanLocked()
         }
-        saveCurrentPlan()
     }
 
     suspend fun loadPlan(planId: String): Boolean {
-        val plan = planRepository.getPlanById(planId)
-        return if (plan != null) {
+        val plan = planRepository.getPlanById(planId) ?: return false
+        mutex.withLock {
             _currentPlan.value = plan
             workingMemory.activePlan = plan
-            true
-        } else {
-            false
         }
+        return true
     }
 
     suspend fun saveCurrentPlan() {
+        mutex.withLock {
+            saveCurrentPlanLocked()
+        }
+    }
+
+    /**
+     * Persists whatever is currently in [_currentPlan]. Must only be called
+     * while holding [mutex] so the value it reads can never be a
+     * half-applied write from a concurrent mutator.
+     */
+    private suspend fun saveCurrentPlanLocked() {
         val plan = _currentPlan.value ?: return
         planRepository.savePlan(plan)
     }
 
     fun clearPlan() {
-        _currentPlan.value = null
-        workingMemory.activePlan = null
+        scope.launch {
+            mutex.withLock {
+                _currentPlan.value = null
+                workingMemory.activePlan = null
+            }
+        }
     }
 
+    /**
+     * Marks the current plan (if any) as cancelled and clears it from working
+     * memory. Safe to call when there is no active plan, and a no-op when the
+     * plan sitting in [_currentPlan] has already reached a terminal status
+     * (COMPLETED, FAILED, or CANCELLED).
+     *
+     * That terminal-status guard is load-bearing, not defensive dressing: unlike
+     * every other mutator here, callers of cancelPlan() in AgentLoop (see
+     * cancelCurrentTask, resolveStaleProposedPlan, abandonWaitingTask) don't
+     * necessarily know whether a task is genuinely still running - e.g.
+     * cancelCurrentTask() is documented as "safe to call when nothing is
+     * running", and when nothing was running, whatever plan is still parked in
+     * [_currentPlan] is the *last finished* plan (PlanScreen intentionally keeps
+     * showing it there after completion - see updatePlanStatus). Without this
+     * guard, a call with nothing actually in flight would relabel that finished
+     * plan CANCELLED and persist that lie over its real COMPLETED/FAILED row.
+     * Once a plan has reached a terminal status, it is done - nothing may ever
+     * move it to a different status again.
+     *
+     * [expectedPlanId], when non-null, adds a second, independent guard: this
+     * only applies CANCELLED when the plan currently held here is STILL the one
+     * identified by that id. AgentLoop's cancellation paths (cancelCurrentTask,
+     * abandonWaitingTask, resolveStaleProposedPlan) fire their join-then-cancel
+     * follow-up on a separate coroutine that can run arbitrarily later than the
+     * moment cancellation was actually requested - by then a brand-new,
+     * completely unrelated task may already have replaced [_currentPlan] via
+     * [startNewPlan]. Without this check, cancelPlan() would happily relabel
+     * that new plan CANCELLED (the terminal-status guard above does NOT catch
+     * this - a fresh plan starts RUNNING, not terminal) purely because it
+     * happened to be whatever was "current" when this coroutine got around to
+     * running. Passing null keeps the old "cancel whatever is current"
+     * behaviour for any caller that genuinely means that.
+     */
+    suspend fun cancelPlan(expectedPlanId: String? = null) {
+        mutex.withLock {
+            val plan = _currentPlan.value ?: return@withLock
+            if (plan.status.isTerminal()) return@withLock
+            if (expectedPlanId != null && plan.planId != expectedPlanId) return@withLock
+            val updatedPlan = plan.copy(status = PlanStatus.CANCELLED)
+            _currentPlan.value = updatedPlan
+            workingMemory.activePlan = null
+            saveCurrentPlanLocked()
+        }
+    }
+
+    /**
+     * Updates the description of a step that has not started executing yet.
+     * No-op if the step cannot be found or is no longer PENDING, so an
+     * in-flight or already-finished step can never be mutated out from
+     * under the executor.
+     */
+    suspend fun updateStepDescription(stepId: String, description: String) {
+        mutex.withLock {
+            val plan = _currentPlan.value ?: return@withLock
+            val targetStep = plan.steps.find { it.stepId == stepId } ?: return@withLock
+            if (targetStep.status != StepStatus.PENDING) return@withLock
+            val updatedSteps = plan.steps.map { step ->
+                if (step.stepId == stepId) step.copy(description = description) else step
+            }
+            val updatedPlan = plan.copy(steps = updatedSteps)
+            _currentPlan.value = updatedPlan
+            workingMemory.activePlan = updatedPlan
+            saveCurrentPlanLocked()
+        }
+    }
+
+    /**
+     * Replaces the params map of a step that has not started executing yet.
+     * No-op if the step cannot be found or is no longer PENDING. Executing
+     * this while the plan is RUNNING lets executePlanLoop pick up the new
+     * params the next time it reads this step via getActiveStep().
+     */
+    suspend fun updateStepParams(stepId: String, params: Map<String, String>) {
+        mutex.withLock {
+            val plan = _currentPlan.value ?: return@withLock
+            val targetStep = plan.steps.find { it.stepId == stepId } ?: return@withLock
+            if (targetStep.status != StepStatus.PENDING) return@withLock
+            val updatedSteps = plan.steps.map { step ->
+                if (step.stepId == stepId) step.copy(params = params) else step
+            }
+            val updatedPlan = plan.copy(steps = updatedSteps)
+            _currentPlan.value = updatedPlan
+            workingMemory.activePlan = updatedPlan
+            saveCurrentPlanLocked()
+        }
+    }
+
+    /**
+     * Atomically updates both the description and params of a step that has not started
+     * executing yet, in a single mutex-guarded read-modify-write. Prefer this over calling
+     * [updateStepDescription] then [updateStepParams] back to back: those are two
+     * independent suspend calls, so a concurrent reader (executePlanLoop's
+     * [getStepSnapshot], or anything else observing [currentPlan]) can land between them
+     * and see the new description paired with the still-old params - a half-applied edit
+     * that then gets persisted and executed as if it were what the user asked for. No-op
+     * if the step cannot be found or is no longer PENDING.
+     */
+    suspend fun updateStep(stepId: String, description: String, params: Map<String, String>) {
+        mutex.withLock {
+            val plan = _currentPlan.value ?: return@withLock
+            val targetStep = plan.steps.find { it.stepId == stepId } ?: return@withLock
+            if (targetStep.status != StepStatus.PENDING) return@withLock
+            val updatedSteps = plan.steps.map { step ->
+                if (step.stepId == stepId) step.copy(description = description, params = params) else step
+            }
+            val updatedPlan = plan.copy(steps = updatedSteps)
+            _currentPlan.value = updatedPlan
+            workingMemory.activePlan = updatedPlan
+            saveCurrentPlanLocked()
+        }
+    }
+
+    /**
+     * Removes a step that has not started executing yet from the current
+     * plan. No-op if the step cannot be found or is no longer PENDING.
+     */
+    suspend fun removeStep(stepId: String) {
+        mutex.withLock {
+            val plan = _currentPlan.value ?: return@withLock
+            val targetStep = plan.steps.find { it.stepId == stepId } ?: return@withLock
+            if (targetStep.status != StepStatus.PENDING) return@withLock
+            val updatedSteps = plan.steps.filterNot { it.stepId == stepId }
+            val updatedPlan = plan.copy(steps = updatedSteps)
+            _currentPlan.value = updatedPlan
+            workingMemory.activePlan = updatedPlan
+            saveCurrentPlanLocked()
+        }
+    }
+
+    /**
+     * Re-reads a single step's current description/params/action directly from the
+     * source of truth. Meant to be called by executePlanLoop immediately before it
+     * dispatches a step, to close the window between its earlier (unguarded)
+     * [getActiveStep] snapshot and the actual dispatch - the Plan-tab step editor
+     * (updateStepDescription then updateStepParams) can land in that window, and
+     * without this re-read its edit would be persisted to the DB yet silently ignored
+     * by the execution already in flight.
+     *
+     * Mutex-guarded like the mutators above, so it always observes either a fully
+     * applied edit or none of it, never a half-applied intermediate write. Must NOT be
+     * called from within a block that already holds [mutex] - see its doc comment -
+     * that would deadlock.
+     */
+    suspend fun getStepSnapshot(stepId: String): PlanStep? {
+        mutex.withLock {
+            return _currentPlan.value?.steps?.find { it.stepId == stepId }
+        }
+    }
+
+    /**
+     * Not mutex-guarded: this only takes a single snapshot of the
+     * StateFlow's current value and reads from that local, immutable [Plan]
+     * (steps is a List<PlanStep> of immutable data classes), so there is no
+     * read-modify-write here to race - just one atomic read of a reference
+     * that can never be torn.
+     */
     fun getActiveStep(): PlanStep? {
         val plan = _currentPlan.value ?: return null
         if (plan.status != PlanStatus.RUNNING) return null
@@ -86,6 +291,13 @@ class PlanManager @Inject constructor(
             step.status == StepStatus.PENDING && hasDependenciesMet(step, plan.steps)
         }
     }
+
+    /**
+     * A plan in one of these statuses is done: nothing may ever relabel it into a
+     * different status again. See [cancelPlan].
+     */
+    private fun PlanStatus.isTerminal(): Boolean =
+        this == PlanStatus.COMPLETED || this == PlanStatus.FAILED || this == PlanStatus.CANCELLED
 
     private fun hasDependenciesMet(step: PlanStep, allSteps: List<PlanStep>): Boolean {
         if (step.dependsOn.isEmpty()) return true

--- a/app/src/main/java/com/opendroid/ai/core/llm/prompts/PlanningPrompts.kt
+++ b/app/src/main/java/com/opendroid/ai/core/llm/prompts/PlanningPrompts.kt
@@ -31,12 +31,37 @@ CRITICAL DEPENDENCY RULES:
 SELF-CONTAINED ACTIONS (do NOT add OPEN_APP before these):
 - SEND_WHATSAPP, MAKE_CALL, SEND_SMS, SEND_EMAIL — these open the app internally.
 - BOOK_UBER, BOOK_OLA — these open the ride app internally.
-- PLAY_MUSIC, PLAY_YOUTUBE — these open the media app internally.
+- PLAY_MUSIC, PLAY_YOUTUBE — these open the media app internally AND perform the
+  search/play. They already handle phrasing like "open youtube and search X" or
+  "open youtube and play X" — the "and search"/"and play" is NOT a second step.
 
 CRITICAL: NEVER generate OPEN_APP as a separate step before a self-contained action.
+NEVER decompose a self-contained action into OPEN_APP + CLICK_TEXT/TYPE_TEXT — the
+target app is still cold-starting when CLICK_TEXT/TYPE_TEXT would run, and typing
+into a field does not submit a search on its own.
   WRONG: Step 1: OPEN_APP {appName: "WhatsApp"}, Step 2: SEND_WHATSAPP {contact: "dad", message: "hi"}
   CORRECT: Step 1: SEND_WHATSAPP {contact: "dad", message: "hi"}
   "open whatsapp and send hi to dad" = just SEND_WHATSAPP (1 step, not 2)
+
+  WRONG: Step 1: OPEN_APP {appName: "YouTube"}, Step 2: CLICK_TEXT {text: "Search"}, Step 3: TYPE_TEXT {searchText: "Search", content: "cat videos"}
+  CORRECT: Step 1: PLAY_YOUTUBE {query: "cat videos"}
+  "open youtube and search cat videos" = just PLAY_YOUTUBE (1 step, not 3)
+  "youtube search lofi" = just PLAY_YOUTUBE {query: "lofi"} (1 step, not 3)
+
+GENUINE IN-APP AUTOMATION (only when the target app has no self-contained action):
+- Use CLICK_TEXT/CLICK_ID/TYPE_TEXT/TYPE_ID/SCROLL to interact with a freshly opened
+  app's UI when no dedicated action exists for what the user wants.
+- Insert a WAIT step (params: {durationMs: "1500"}) right after OPEN_APP so the app
+  finishes loading before the next step looks for UI elements — CLICK_TEXT/TYPE_TEXT
+  search for an element once and fail if the app hasn't rendered it yet.
+- After TYPE_TEXT/TYPE_ID fills in a search box, add a PRESS_ENTER step to actually
+  submit it — typing text alone does not run the search.
+  Example: "open settings and search for battery saver" (no dedicated settings-search
+  action exists) =
+    Step 1: OPEN_APP {appName: "Settings"}
+    Step 2: WAIT {durationMs: "1500"}
+    Step 3: TYPE_TEXT {searchText: "Search settings", content: "battery saver"}
+    Step 4: PRESS_ENTER {}
 
 Always return the structured PLAN JSON format, even if the user request can be accomplished in a single step (in which case, return a plan with a single step in the steps list). Avoid hardcoding variables when a previous step's output is required (e.g., dependsOn mapping). All parameter values in "params" must be Strings.
 

--- a/app/src/main/java/com/opendroid/ai/core/memory/EpisodicMemory.kt
+++ b/app/src/main/java/com/opendroid/ai/core/memory/EpisodicMemory.kt
@@ -9,10 +9,24 @@ import javax.inject.Singleton
 class EpisodicMemory @Inject constructor(
     private val conversationRepository: ConversationRepository
 ) {
+    /** Stores [message] into whichever session is current at call time. */
     suspend fun storeMessage(message: ChatMessage) {
         conversationRepository.insertMessage(message)
     }
 
+    /**
+     * Stores [message] into [sessionId] specifically. Use this from a caller that has
+     * already pinned a session for a whole task (see AgentLoop) so the write can't drift
+     * to whichever chat happens to be current by the time this call actually runs.
+     */
+    suspend fun storeMessage(message: ChatMessage, sessionId: String) {
+        conversationRepository.insertMessage(sessionId, message)
+    }
+
+    /**
+     * Searches the current session's recent history only - chats are independent
+     * conversations, so a search here deliberately does not bleed across chats.
+     */
     suspend fun searchLogs(query: String): List<ChatMessage> {
         return conversationRepository.getLastMessages(100).filter {
             it.text.contains(query, ignoreCase = true)

--- a/app/src/main/java/com/opendroid/ai/core/memory/MemoryManager.kt
+++ b/app/src/main/java/com/opendroid/ai/core/memory/MemoryManager.kt
@@ -8,6 +8,7 @@ import com.opendroid.ai.data.repository.MemoryRepository
 import android.content.Context
 import android.util.Log
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.first
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
@@ -28,12 +29,28 @@ class MemoryManager @Inject constructor(
 ) {
     private val json = Json { prettyPrint = true }
 
+    /** Stores [message] into whichever session is current at call time. */
     suspend fun storeMessage(message: ChatMessage) {
         workingMemory.addMessage(message)
         episodicMemory.storeMessage(message)
 
         // Automatically extract facts from the latest conversation turn
         val recent = conversationRepository.getLastMessages(5)
+        extractFacts(recent)
+    }
+
+    /**
+     * Stores [message] into [sessionId] specifically. Use this from a caller that has
+     * already pinned a session for a whole task (see AgentLoop) so the write - and the
+     * fact-extraction context it triggers - can't drift to whichever chat happens to be
+     * current by the time this call actually runs.
+     */
+    suspend fun storeMessage(message: ChatMessage, sessionId: String) {
+        workingMemory.addMessage(message)
+        episodicMemory.storeMessage(message, sessionId)
+
+        // Automatically extract facts from the latest conversation turn
+        val recent = conversationRepository.getLastMessages(sessionId, 5)
         extractFacts(recent)
     }
 
@@ -82,9 +99,13 @@ class MemoryManager @Inject constructor(
         // Notification intelligence context
         val notifSummary = try {
             notificationIntelligence.getRecentNotificationSummary(5)
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) { "" }
         val learnedPatterns = try {
             notificationIntelligence.getLearnedPatterns()
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) { "" }
         val notifSection = if (notifSummary.isNotBlank() || learnedPatterns.isNotBlank()) {
             // Notification text is written by third parties — mark it untrusted so
@@ -140,7 +161,11 @@ class MemoryManager @Inject constructor(
             workingMemory.clear()
         }
         if (type == MemoryType.EPISODIC) {
-            conversationRepository.clearAll()
+            // The Memory tab's episodic clear is labeled as wiping history outright, so it
+            // must hit every chat, not just whichever one happens to be current right now.
+            // Clearing only the current chat is ChatViewModel.clearChat()'s job, via
+            // ConversationRepository.clearCurrentSession().
+            conversationRepository.clearAllSessions()
         }
         if (type == MemoryType.PROCEDURAL) {
             memoryRepository.clearAllMacros()

--- a/app/src/main/java/com/opendroid/ai/core/util/UrlUtils.kt
+++ b/app/src/main/java/com/opendroid/ai/core/util/UrlUtils.kt
@@ -1,0 +1,42 @@
+package com.opendroid.ai.core.util
+
+/**
+ * Normalizes user-entered base URLs for self-hosted / custom LLM endpoints
+ * (Ollama, Copilot proxy, custom OpenAI-compatible servers).
+ *
+ * User input is often messy: a missing scheme ("192.168.1.5:11434"), trailing
+ * slashes ("https://myserver.com/"), or surrounding whitespace. [formatBaseUrl]
+ * cleans that up so callers can safely append a path (e.g. "$baseUrl/api/tags")
+ * without producing a double slash or a scheme-less URL that OkHttp would reject.
+ */
+object UrlUtils {
+
+    /**
+     * Returns a normalized base URL (no trailing slash, scheme guaranteed) built
+     * from [rawUrl]. If [rawUrl] is blank, [fallback] is normalized and returned
+     * instead. If both are blank, returns an empty string rather than throwing,
+     * so callers can decide how to handle "not configured".
+     */
+    fun formatBaseUrl(rawUrl: String?, fallback: String = ""): String {
+        val normalizedInput = normalize(rawUrl)
+        if (normalizedInput.isNotEmpty()) return normalizedInput
+        return normalize(fallback)
+    }
+
+    private fun normalize(url: String?): String {
+        var trimmed = url?.trim().orEmpty()
+        if (trimmed.isEmpty()) return ""
+
+        // Strip whitespace that may appear mid-string from copy/paste mistakes.
+        trimmed = trimmed.replace(" ", "")
+        if (trimmed.isEmpty()) return ""
+
+        // Default self-hosted endpoints to http:// when no scheme is present —
+        // local Ollama/Copilot-proxy servers are typically plain HTTP on a LAN.
+        val withScheme = if (trimmed.contains("://")) trimmed else "http://$trimmed"
+
+        // Collapse any trailing slashes so callers never end up with "//" when
+        // they concatenate a path suffix onto the result.
+        return withScheme.trimEnd('/')
+    }
+}

--- a/app/src/main/java/com/opendroid/ai/core/voice/SpeechRecognitionEngine.kt
+++ b/app/src/main/java/com/opendroid/ai/core/voice/SpeechRecognitionEngine.kt
@@ -13,6 +13,15 @@ class SpeechRecognitionEngine(private val context: Context) {
     private var speechRecognizer: SpeechRecognizer? = null
     private var recognizerIntent: Intent? = null
 
+    // Identifies the currently active recognition session. Every startListening() call mints a
+    // new token and each RecognitionListener callback closure captures the token it was created
+    // with, comparing it against [activeSessionId] before delivering anything. This guards
+    // against a stale onResults/onPartialResults/onError callback arriving from a session that
+    // was already cancelled (isCancelled-style guard) *and* from a session that was superseded by
+    // a newer startListening() call - either case bumps [activeSessionId] so the old callback's
+    // captured token no longer matches and the delivery is dropped.
+    private var activeSessionId = 0
+
     init {
         initializeRecognizer()
     }
@@ -43,14 +52,21 @@ class SpeechRecognitionEngine(private val context: Context) {
             return
         }
 
+        // Mint a new session token and let this specific listener closure capture it. Any
+        // callback delivered to a listener whose captured token no longer matches
+        // [activeSessionId] belongs to a cancelled or superseded session and is dropped.
+        activeSessionId += 1
+        val sessionId = activeSessionId
+
         speechRecognizer?.setRecognitionListener(object : RecognitionListener {
             override fun onReadyForSpeech(params: Bundle?) {}
             override fun onBeginningOfSpeech() {}
             override fun onRmsChanged(rmsdB: Float) {}
             override fun onBufferReceived(buffer: ByteArray?) {}
             override fun onEndOfSpeech() {}
-            
+
             override fun onError(error: Int) {
+                if (sessionId != activeSessionId) return
                 val message = when (error) {
                     SpeechRecognizer.ERROR_AUDIO -> "Audio recording error"
                     SpeechRecognizer.ERROR_CLIENT -> "Client side error"
@@ -67,6 +83,7 @@ class SpeechRecognitionEngine(private val context: Context) {
             }
 
             override fun onResults(results: Bundle?) {
+                if (sessionId != activeSessionId) return
                 val matches = results?.getStringArrayList(SpeechRecognizer.RESULTS_RECOGNITION)
                 if (!matches.isNullOrEmpty()) {
                     onResult(matches[0])
@@ -76,6 +93,7 @@ class SpeechRecognitionEngine(private val context: Context) {
             }
 
             override fun onPartialResults(partialResults: Bundle?) {
+                if (sessionId != activeSessionId) return
                 val matches = partialResults?.getStringArrayList(SpeechRecognizer.RESULTS_RECOGNITION)
                 if (!matches.isNullOrEmpty()) {
                     onPartialResult(matches[0])
@@ -92,7 +110,22 @@ class SpeechRecognitionEngine(private val context: Context) {
         speechRecognizer?.stopListening()
     }
 
+    /**
+     * Cancels the in-progress recognition session outright. Unlike [stopListening], the
+     * recognizer is guaranteed not to deliver a subsequent onResults/onPartialResults callback
+     * for this session - any such callback still in flight is dropped because the session token
+     * it captured no longer matches [activeSessionId] once it has been bumped here.
+     */
+    fun cancel() {
+        activeSessionId += 1
+        speechRecognizer?.cancel()
+    }
+
     fun destroy() {
+        // Invalidate the active session so a callback that was already in flight cannot fire
+        // (e.g. deliver a result) after this engine - and the Composable that owns it - has
+        // been disposed.
+        activeSessionId += 1
         speechRecognizer?.destroy()
         speechRecognizer = null
     }

--- a/app/src/main/java/com/opendroid/ai/data/db/OpenDroidDatabase.kt
+++ b/app/src/main/java/com/opendroid/ai/data/db/OpenDroidDatabase.kt
@@ -4,11 +4,13 @@ import androidx.room.Database
 import androidx.room.RoomDatabase
 import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
+import com.opendroid.ai.data.db.dao.ChatSessionDao
 import com.opendroid.ai.data.db.dao.ConversationDao
 import com.opendroid.ai.data.db.dao.MacroDao
 import com.opendroid.ai.data.db.dao.MemoryDao
 import com.opendroid.ai.data.db.dao.PlanDao
 import com.opendroid.ai.data.db.dao.TaskHistoryDao
+import com.opendroid.ai.data.db.entities.ChatSessionEntity
 import com.opendroid.ai.data.db.entities.ConversationEntity
 import com.opendroid.ai.data.db.entities.MacroEntity
 import com.opendroid.ai.data.db.entities.MemoryEntity
@@ -26,6 +28,7 @@ import androidx.room.TypeConverters
 @Database(
     entities = [
         ConversationEntity::class,
+        ChatSessionEntity::class,
         PlanEntity::class,
         MemoryEntity::class,
         TaskHistoryEntity::class,
@@ -34,12 +37,13 @@ import androidx.room.TypeConverters
         NotificationEntity::class,
         ModelEntity::class
     ],
-    version = 5,
+    version = 6,
     exportSchema = false
 )
 @TypeConverters(Converters::class)
 abstract class OpenDroidDatabase : RoomDatabase() {
     abstract fun conversationDao(): ConversationDao
+    abstract fun chatSessionDao(): ChatSessionDao
     abstract fun planDao(): PlanDao
     abstract fun memoryDao(): MemoryDao
     abstract fun taskHistoryDao(): TaskHistoryDao
@@ -49,6 +53,10 @@ abstract class OpenDroidDatabase : RoomDatabase() {
     abstract fun modelDao(): ModelDao
 
     companion object {
+        // Id of the single session that pre-existing conversation rows are
+        // backfilled onto by MIGRATION_5_6. Not used post-migration - new
+        // sessions get randomly generated ids (see ConversationRepository).
+        private const val DEFAULT_SESSION_ID = "default_session"
         val MIGRATION_1_2 = object : Migration(1, 2) {
             override fun migrate(database: SupportSQLiteDatabase) {
                 database.execSQL("ALTER TABLE conversations ADD COLUMN contactPickerData TEXT DEFAULT NULL")
@@ -100,6 +108,45 @@ abstract class OpenDroidDatabase : RoomDatabase() {
                         etaString TEXT NOT NULL DEFAULT ''
                     )
                 """)
+            }
+        }
+
+        val MIGRATION_5_6 = object : Migration(5, 6) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                // 1. New table backing multiple chat histories.
+                database.execSQL("""
+                    CREATE TABLE IF NOT EXISTS chat_sessions (
+                        id TEXT PRIMARY KEY NOT NULL,
+                        title TEXT NOT NULL,
+                        createdAt INTEGER NOT NULL,
+                        updatedAt INTEGER NOT NULL,
+                        isCurrent INTEGER NOT NULL DEFAULT 0
+                    )
+                """)
+
+                // 2. Seed exactly one session that existing chat history will be
+                // attached to. INSERT OR IGNORE makes this safe to re-run.
+                val now = System.currentTimeMillis()
+                database.execSQL(
+                    "INSERT OR IGNORE INTO chat_sessions (id, title, createdAt, updatedAt, isCurrent) " +
+                        "VALUES ('$DEFAULT_SESSION_ID', 'Chat', $now, $now, 1)"
+                )
+
+                // 3. Add the session pointer to conversations. SQLite backfills the
+                // DEFAULT value into every pre-existing row as part of this ALTER,
+                // and the explicit UPDATE below makes that backfill unmistakable -
+                // no existing chat history is lost by this migration.
+                database.execSQL(
+                    "ALTER TABLE conversations ADD COLUMN sessionId TEXT NOT NULL DEFAULT '$DEFAULT_SESSION_ID'"
+                )
+                database.execSQL(
+                    "UPDATE conversations SET sessionId = '$DEFAULT_SESSION_ID'"
+                )
+
+                // 4. Matches the @Index Room expects on ConversationEntity.sessionId.
+                database.execSQL(
+                    "CREATE INDEX IF NOT EXISTS index_conversations_sessionId ON conversations(sessionId)"
+                )
             }
         }
     }

--- a/app/src/main/java/com/opendroid/ai/data/db/dao/ChatSessionDao.kt
+++ b/app/src/main/java/com/opendroid/ai/data/db/dao/ChatSessionDao.kt
@@ -1,0 +1,44 @@
+package com.opendroid.ai.data.db.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.opendroid.ai.data.db.entities.ChatSessionEntity
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface ChatSessionDao {
+    /** All sessions, most recently active first. */
+    @Query("SELECT * FROM chat_sessions ORDER BY updatedAt DESC")
+    fun getAllSessions(): Flow<List<ChatSessionEntity>>
+
+    @Query("SELECT * FROM chat_sessions WHERE isCurrent = 1 LIMIT 1")
+    fun getCurrentSession(): Flow<ChatSessionEntity?>
+
+    @Query("SELECT * FROM chat_sessions WHERE isCurrent = 1 LIMIT 1")
+    suspend fun getCurrentSessionOnce(): ChatSessionEntity?
+
+    /** Most recently active session id, used as a fallback when there is no current session. */
+    @Query("SELECT id FROM chat_sessions ORDER BY updatedAt DESC LIMIT 1")
+    suspend fun getAnySessionId(): String?
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(session: ChatSessionEntity)
+
+    /**
+     * Marks [sessionId] as the current session and un-marks every other one in the
+     * same statement, so there is never a moment with zero or two current sessions.
+     */
+    @Query("UPDATE chat_sessions SET isCurrent = (id = :sessionId)")
+    suspend fun markCurrent(sessionId: String)
+
+    @Query("UPDATE chat_sessions SET updatedAt = :timestamp WHERE id = :sessionId")
+    suspend fun touch(sessionId: String, timestamp: Long)
+
+    @Query("UPDATE chat_sessions SET title = :title, updatedAt = :timestamp WHERE id = :sessionId")
+    suspend fun rename(sessionId: String, title: String, timestamp: Long)
+
+    @Query("DELETE FROM chat_sessions WHERE id = :sessionId")
+    suspend fun delete(sessionId: String)
+}

--- a/app/src/main/java/com/opendroid/ai/data/db/dao/ConversationDao.kt
+++ b/app/src/main/java/com/opendroid/ai/data/db/dao/ConversationDao.kt
@@ -17,4 +17,37 @@ interface ConversationDao {
 
     @Query("DELETE FROM conversations")
     suspend fun clearAll()
+
+    /** Messages of a single chat session, oldest first, reactive to inserts/deletes. */
+    @Query("SELECT * FROM conversations WHERE sessionId = :sessionId ORDER BY timestamp ASC")
+    fun getMessagesForSession(sessionId: String): Flow<List<ConversationEntity>>
+
+    /** Newest-first, capped at [limit]; callers wanting chronological order should reverse it. */
+    @Query("SELECT * FROM conversations WHERE sessionId = :sessionId ORDER BY timestamp DESC LIMIT :limit")
+    suspend fun getLastMessagesForSession(sessionId: String, limit: Int): List<ConversationEntity>
+
+    /** Deletes a single message by id, regardless of which session it belongs to. */
+    @Query("DELETE FROM conversations WHERE id = :messageId")
+    suspend fun deleteMessage(messageId: String)
+
+    /**
+     * Deletes [messageId] together with every message inserted after it in
+     * [sessionId] (by insertion order, i.e. SQLite rowid). This is the
+     * "edit and resend" primitive: drop the edited message and every reply
+     * that followed it so the edited text can be resubmitted as a new turn.
+     */
+    @Query(
+        """
+        DELETE FROM conversations
+        WHERE sessionId = :sessionId
+        AND rowid >= (
+            SELECT rowid FROM conversations WHERE id = :messageId AND sessionId = :sessionId
+        )
+        """
+    )
+    suspend fun deleteMessageAndAfter(sessionId: String, messageId: String)
+
+    /** Clears every message of a single session, leaving other sessions untouched. */
+    @Query("DELETE FROM conversations WHERE sessionId = :sessionId")
+    suspend fun clearSession(sessionId: String)
 }

--- a/app/src/main/java/com/opendroid/ai/data/db/entities/ChatSessionEntity.kt
+++ b/app/src/main/java/com/opendroid/ai/data/db/entities/ChatSessionEntity.kt
@@ -1,0 +1,22 @@
+package com.opendroid.ai.data.db.entities
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+/**
+ * A single chat history. The app supports multiple independent chat sessions
+ * instead of one global conversation; [ConversationEntity.sessionId] points
+ * back at the owning row here.
+ *
+ * [isCurrent] marks the session currently shown/appended to. Exactly one row
+ * should have isCurrent = true at any time - always flip it via
+ * ChatSessionDao.markCurrent, which clears every other row atomically.
+ */
+@Entity(tableName = "chat_sessions")
+data class ChatSessionEntity(
+    @PrimaryKey val id: String,
+    val title: String,
+    val createdAt: Long,
+    val updatedAt: Long,
+    val isCurrent: Boolean = false
+)

--- a/app/src/main/java/com/opendroid/ai/data/db/entities/ConversationEntity.kt
+++ b/app/src/main/java/com/opendroid/ai/data/db/entities/ConversationEntity.kt
@@ -1,14 +1,20 @@
 package com.opendroid.ai.data.db.entities
 
 import androidx.room.Entity
+import androidx.room.Index
 import androidx.room.PrimaryKey
 
-@Entity(tableName = "conversations")
+@Entity(
+    tableName = "conversations",
+    indices = [Index(value = ["sessionId"])]
+)
 data class ConversationEntity(
     @PrimaryKey val id: String,
     val text: String,
     val sender: String, // "USER" or "AGENT"
     val timestamp: Long,
     val modelBadge: String? = null,
-    val contactPickerData: String? = null
+    val contactPickerData: String? = null,
+    // Which chat history this message belongs to. See ChatSessionEntity.
+    val sessionId: String
 )

--- a/app/src/main/java/com/opendroid/ai/data/repository/ConversationRepository.kt
+++ b/app/src/main/java/com/opendroid/ai/data/repository/ConversationRepository.kt
@@ -1,57 +1,220 @@
 package com.opendroid.ai.data.repository
 
+import androidx.room.withTransaction
+import com.opendroid.ai.data.db.OpenDroidDatabase
+import com.opendroid.ai.data.db.dao.ChatSessionDao
 import com.opendroid.ai.data.db.dao.ConversationDao
+import com.opendroid.ai.data.db.entities.ChatSessionEntity
 import com.opendroid.ai.data.db.entities.ConversationEntity
 import com.opendroid.ai.data.models.ChatMessage
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import java.util.UUID
 import javax.inject.Inject
 import javax.inject.Singleton
 
+/**
+ * A single chat history. The app keeps multiple independent sessions instead
+ * of one global conversation; [isCurrent] mirrors whichever one is active.
+ */
+data class ChatSession(
+    val id: String,
+    val title: String,
+    val createdAt: Long,
+    val updatedAt: Long,
+    val isCurrent: Boolean
+)
+
 @Singleton
 class ConversationRepository @Inject constructor(
-    private val conversationDao: ConversationDao
+    private val database: OpenDroidDatabase,
+    private val conversationDao: ConversationDao,
+    private val chatSessionDao: ChatSessionDao
 ) {
-    val conversations: Flow<List<ChatMessage>> = conversationDao.getAllConversations().map { entities ->
-        entities.map { entity ->
-            ChatMessage(
-                id = entity.id,
-                text = entity.text,
-                sender = ChatMessage.Sender.valueOf(entity.sender),
-                timestamp = entity.timestamp,
-                modelBadge = entity.modelBadge,
-                contactPickerData = entity.contactPickerData
-            )
+    // Serializes lazy creation of the very first session so concurrent callers
+    // (e.g. two ViewModels reading history at app startup) can't each insert
+    // their own session - a fresh install must end up with exactly one.
+    private val ensureSessionMutex = Mutex()
+
+    /**
+     * Messages of the currently active session, oldest first. Reactive to both
+     * message changes and to the user switching sessions - the current-session
+     * flag lives in [chatSessionDao], so a session switch alone re-triggers this.
+     */
+    val conversations: Flow<List<ChatMessage>> = chatSessionDao.getCurrentSession()
+        .map { it?.id }
+        .distinctUntilChanged()
+        .flatMapLatest { sessionId ->
+            conversationDao.getMessagesForSession(sessionId ?: ensureCurrentSessionId())
         }
+        .map { entities -> entities.map { it.toChatMessage() } }
+
+    /** Every chat session, most recently active first. */
+    val sessions: Flow<List<ChatSession>> = chatSessionDao.getAllSessions().map { entities ->
+        entities.map { it.toChatSession() }
     }
 
+    /** Reactive id of the current session; null only before the first session exists. */
+    val currentSessionId: Flow<String?> = chatSessionDao.getCurrentSession().map { it?.id }
+
+    /** Messages of an arbitrary session (not necessarily the current one), oldest first. */
+    fun getMessages(sessionId: String): Flow<List<ChatMessage>> =
+        conversationDao.getMessagesForSession(sessionId).map { entities ->
+            entities.map { it.toChatMessage() }
+        }
+
+    /** Inserts [message] into the current session, lazily creating one if needed. */
     suspend fun insertMessage(message: ChatMessage) {
-        conversationDao.insertMessage(
-            ConversationEntity(
-                id = message.id,
-                text = message.text,
-                sender = message.sender.name,
-                timestamp = message.timestamp,
-                modelBadge = message.modelBadge,
-                contactPickerData = message.contactPickerData
-            )
-        )
+        insertMessage(ensureCurrentSessionId(), message)
     }
 
-    suspend fun getLastMessages(limit: Int): List<ChatMessage> {
-        return conversationDao.getLastMessages(limit).map { entity ->
-            ChatMessage(
-                id = entity.id,
-                text = entity.text,
-                sender = ChatMessage.Sender.valueOf(entity.sender),
-                timestamp = entity.timestamp,
-                modelBadge = entity.modelBadge,
-                contactPickerData = entity.contactPickerData
-            )
+    /** Inserts [message] into a specific session. */
+    suspend fun insertMessage(sessionId: String, message: ChatMessage) {
+        conversationDao.insertMessage(message.toEntity(sessionId))
+        chatSessionDao.touch(sessionId, message.timestamp)
+    }
+
+    /** Last [limit] messages of the current session, chronological order. */
+    suspend fun getLastMessages(limit: Int): List<ChatMessage> =
+        getLastMessages(ensureCurrentSessionId(), limit)
+
+    /** Last [limit] messages of [sessionId], chronological order. */
+    suspend fun getLastMessages(sessionId: String, limit: Int): List<ChatMessage> {
+        return conversationDao.getLastMessagesForSession(sessionId, limit).map { entity ->
+            entity.toChatMessage()
         }.reversed()
     }
 
-    suspend fun clearAll() {
+    /**
+     * Clears every message of the current session only. Other sessions are untouched.
+     * This is what "clear this chat" means - see [clearAllSessions] for wiping history
+     * across every chat.
+     */
+    suspend fun clearCurrentSession() {
+        clearSession(ensureCurrentSessionId())
+    }
+
+    /** Clears every message of [sessionId], leaving the session itself intact. */
+    suspend fun clearSession(sessionId: String) {
+        conversationDao.clearSession(sessionId)
+    }
+
+    /**
+     * Clears every message in every session - a true "wipe all history". Sessions
+     * themselves (and their titles) are preserved, just emptied. Used for the Memory
+     * tab's episodic-memory clear, which is labeled as clearing everything, not just
+     * whichever chat happens to be current.
+     */
+    suspend fun clearAllSessions() {
         conversationDao.clearAll()
     }
+
+    /** Deletes a single message by id. */
+    suspend fun deleteMessage(messageId: String) {
+        conversationDao.deleteMessage(messageId)
+    }
+
+    /**
+     * Deletes [messageId] together with every message sent after it in
+     * [sessionId]. This is the primitive behind "edit and resend": remove the
+     * edited message and whatever followed it, then resubmit the edited text
+     * as a new turn via [insertMessage].
+     */
+    suspend fun deleteMessageAndAfter(sessionId: String, messageId: String) {
+        conversationDao.deleteMessageAndAfter(sessionId, messageId)
+    }
+
+    /** Creates a new, empty session, makes it current, and returns its id. */
+    suspend fun createSession(title: String = "New Chat"): String {
+        val id = UUID.randomUUID().toString()
+        val now = System.currentTimeMillis()
+        database.withTransaction {
+            chatSessionDao.insert(
+                ChatSessionEntity(id = id, title = title, createdAt = now, updatedAt = now, isCurrent = false)
+            )
+            chatSessionDao.markCurrent(id)
+        }
+        return id
+    }
+
+    /** Switches which session [conversations]/[insertMessage]/[getLastMessages]/[clearCurrentSession] act on. */
+    suspend fun switchToSession(sessionId: String) {
+        chatSessionDao.markCurrent(sessionId)
+    }
+
+    /** Renames a session and bumps its updatedAt so it sorts as recently active. */
+    suspend fun renameSession(sessionId: String, title: String) {
+        chatSessionDao.rename(sessionId, title, System.currentTimeMillis())
+    }
+
+    /**
+     * Deletes a session and every message in it. If it was the current session,
+     * another existing session becomes current; if none remain, the next call
+     * that needs a current session (e.g. the next [insertMessage]) lazily
+     * creates a fresh one - the app is never left without an active session.
+     */
+    suspend fun deleteSession(sessionId: String) {
+        database.withTransaction {
+            val wasCurrent = chatSessionDao.getCurrentSessionOnce()?.id == sessionId
+            conversationDao.clearSession(sessionId)
+            chatSessionDao.delete(sessionId)
+            if (wasCurrent) {
+                chatSessionDao.getAnySessionId()?.let { fallback -> chatSessionDao.markCurrent(fallback) }
+            }
+        }
+    }
+
+    /**
+     * Resolves the id of the current session, lazily creating the very first
+     * session on a brand-new install (or after the last session was deleted).
+     * Guarded by [ensureSessionMutex] with a double-check so concurrent callers
+     * and repeated launches never produce duplicate sessions.
+     */
+    suspend fun ensureCurrentSessionId(): String {
+        chatSessionDao.getCurrentSessionOnce()?.let { return it.id }
+        return ensureSessionMutex.withLock {
+            chatSessionDao.getCurrentSessionOnce()?.let { return@withLock it.id }
+            chatSessionDao.getAnySessionId()?.let { existing ->
+                chatSessionDao.markCurrent(existing)
+                return@withLock existing
+            }
+            val id = UUID.randomUUID().toString()
+            val now = System.currentTimeMillis()
+            chatSessionDao.insert(
+                ChatSessionEntity(id = id, title = "New Chat", createdAt = now, updatedAt = now, isCurrent = true)
+            )
+            id
+        }
+    }
+
+    private fun ConversationEntity.toChatMessage() = ChatMessage(
+        id = id,
+        text = text,
+        sender = ChatMessage.Sender.valueOf(sender),
+        timestamp = timestamp,
+        modelBadge = modelBadge,
+        contactPickerData = contactPickerData
+    )
+
+    private fun ChatMessage.toEntity(sessionId: String) = ConversationEntity(
+        id = id,
+        text = text,
+        sender = sender.name,
+        timestamp = timestamp,
+        modelBadge = modelBadge,
+        contactPickerData = contactPickerData,
+        sessionId = sessionId
+    )
+
+    private fun ChatSessionEntity.toChatSession() = ChatSession(
+        id = id,
+        title = title,
+        createdAt = createdAt,
+        updatedAt = updatedAt,
+        isCurrent = isCurrent
+    )
 }

--- a/app/src/main/java/com/opendroid/ai/di/DatabaseModule.kt
+++ b/app/src/main/java/com/opendroid/ai/di/DatabaseModule.kt
@@ -3,6 +3,7 @@ package com.opendroid.ai.di
 import android.content.Context
 import androidx.room.Room
 import com.opendroid.ai.data.db.OpenDroidDatabase
+import com.opendroid.ai.data.db.dao.ChatSessionDao
 import com.opendroid.ai.data.db.dao.ConversationDao
 import com.opendroid.ai.data.db.dao.MacroDao
 import com.opendroid.ai.data.db.dao.MemoryDao
@@ -35,7 +36,8 @@ object DatabaseModule {
             OpenDroidDatabase.MIGRATION_1_2,
             OpenDroidDatabase.MIGRATION_2_3,
             OpenDroidDatabase.MIGRATION_3_4,
-            OpenDroidDatabase.MIGRATION_4_5
+            OpenDroidDatabase.MIGRATION_4_5,
+            OpenDroidDatabase.MIGRATION_5_6
         )
         .fallbackToDestructiveMigration()
         .build()
@@ -44,6 +46,10 @@ object DatabaseModule {
     @Provides
     @Singleton
     fun provideConversationDao(db: OpenDroidDatabase): ConversationDao = db.conversationDao()
+
+    @Provides
+    @Singleton
+    fun provideChatSessionDao(db: OpenDroidDatabase): ChatSessionDao = db.chatSessionDao()
 
     @Provides
     @Singleton

--- a/app/src/main/java/com/opendroid/ai/ui/Navigation.kt
+++ b/app/src/main/java/com/opendroid/ai/ui/Navigation.kt
@@ -15,11 +15,14 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.text.font.FontWeight
 import androidx.core.content.ContextCompat
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -43,12 +46,8 @@ fun OpenDroidNavigation(
                 onNavigateNext = {
                     val sharedPrefs = com.opendroid.ai.core.security.SecurePrefs.get(context)
                     val isOnboardingCompleted = sharedPrefs.getBoolean("onboarding_completed", false)
-                    val hasAudioPermission = ContextCompat.checkSelfPermission(
-                        context,
-                        Manifest.permission.RECORD_AUDIO
-                    ) == PackageManager.PERMISSION_GRANTED
-                    
-                    val destination = if (isOnboardingCompleted && hasAudioPermission) "main" else "onboarding"
+
+                    val destination = if (isOnboardingCompleted) "main" else "onboarding"
                     navController.navigate(destination) {
                         popUpTo("splash") { inclusive = true }
                     }
@@ -91,6 +90,9 @@ fun OpenDroidNavigation(
                 },
                 onNavigateToNotificationHistory = {
                     navController.navigate("notification_history")
+                },
+                onNavigateToPermissions = {
+                    navController.navigate("permissions")
                 }
             )
         }
@@ -164,6 +166,14 @@ fun OpenDroidNavigation(
                 }
             )
         }
+
+        composable("permissions") {
+            PermissionsScreen(
+                onNavigateBack = {
+                    navController.popBackStack()
+                }
+            )
+        }
     }
 }
 
@@ -185,12 +195,30 @@ fun MainDashboard(
     onNavigateToLicense: () -> Unit,
     onNavigateToAbout: () -> Unit,
     onNavigateToAutoReply: () -> Unit = {},
-    onNavigateToNotificationHistory: () -> Unit = {}
+    onNavigateToNotificationHistory: () -> Unit = {},
+    onNavigateToPermissions: () -> Unit = {}
 ) {
     val context = LocalContext.current
-    LaunchedEffect(Unit) {
-        if (ContextCompat.checkSelfPermission(context, Manifest.permission.RECORD_AUDIO) == PackageManager.PERMISSION_GRANTED) {
-            com.opendroid.ai.core.service.OpenDroidService.start(context)
+
+    // Start the service as soon as RECORD_AUDIO is granted, and keep checking on every
+    // resume - not just once on first composition - so a user who grants the microphone
+    // from Settings > Permissions (rather than at onboarding) gets the service started
+    // immediately on returning here, with no app restart required.
+    var recordAudioServiceStarted by remember { mutableStateOf(false) }
+    val lifecycleOwner = LocalLifecycleOwner.current
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME) {
+                val granted = ContextCompat.checkSelfPermission(context, Manifest.permission.RECORD_AUDIO) == PackageManager.PERMISSION_GRANTED
+                if (granted && !recordAudioServiceStarted) {
+                    recordAudioServiceStarted = true
+                    com.opendroid.ai.core.service.OpenDroidService.start(context)
+                }
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose {
+            lifecycleOwner.lifecycle.removeObserver(observer)
         }
     }
 
@@ -271,7 +299,8 @@ fun MainDashboard(
                     onNavigateToLicense = onNavigateToLicense,
                     onNavigateToAbout = onNavigateToAbout,
                     onNavigateToAutoReply = onNavigateToAutoReply,
-                    onNavigateToNotificationHistory = onNavigateToNotificationHistory
+                    onNavigateToNotificationHistory = onNavigateToNotificationHistory,
+                    onNavigateToPermissions = onNavigateToPermissions
                 )
             }
         }

--- a/app/src/main/java/com/opendroid/ai/ui/components/PlanStepCard.kt
+++ b/app/src/main/java/com/opendroid/ai/ui/components/PlanStepCard.kt
@@ -45,9 +45,17 @@ fun getDisplayState(step: PlanStep): StepDisplayState {
 @Composable
 fun PlanStepCard(
     step: PlanStep,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    editable: Boolean = false,
+    onSaveEdit: (description: String, params: Map<String, String>) -> Unit = { _, _ -> },
+    onDeleteStep: () -> Unit = {}
 ) {
     var expanded by remember { mutableStateOf(false) }
+    var isEditing by remember(step.stepId) { mutableStateOf(false) }
+    var editDescription by remember(step.stepId, isEditing) { mutableStateOf(step.description) }
+    var editParams by remember(step.stepId, isEditing) {
+        mutableStateOf(step.params.map { (key, value) -> key to value })
+    }
     val displayState = getDisplayState(step)
 
     val statusColor = when (displayState) {
@@ -67,7 +75,7 @@ fun PlanStepCard(
         modifier = modifier
             .fillMaxWidth()
             .border(1.dp, statusBorderColor, RoundedCornerShape(12.dp))
-            .clickable { expanded = !expanded },
+            .clickable(enabled = !isEditing) { expanded = !expanded },
         colors = CardDefaults.cardColors(containerColor = CardBackground)
     ) {
         Column(modifier = Modifier.padding(14.dp)) {
@@ -106,25 +114,169 @@ fun PlanStepCard(
                     )
                 }
 
-                // Step status icon
-                Icon(
-                    imageVector = when (displayState) {
-                        StepDisplayState.COMPLETED -> Icons.Default.CheckCircle
-                        StepDisplayState.RUNNING -> Icons.Default.Refresh
-                        StepDisplayState.FAILED -> Icons.Default.Close
-                        StepDisplayState.AUTO_FIXING -> Icons.Default.Build
-                        StepDisplayState.REPAIRED -> Icons.Default.CheckCircle
-                        StepDisplayState.SKIPPED -> Icons.Default.ArrowForward
-                        StepDisplayState.BLOCKED -> Icons.Default.Warning
-                        StepDisplayState.PENDING -> Icons.Default.PlayArrow
-                    },
-                    contentDescription = displayState.name,
-                    tint = statusColor,
-                    modifier = Modifier.size(18.dp)
-                )
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    if (editable && !isEditing) {
+                        IconButton(
+                            onClick = { isEditing = true },
+                            modifier = Modifier.size(28.dp)
+                        ) {
+                            Icon(
+                                imageVector = Icons.Default.Edit,
+                                contentDescription = "Edit step",
+                                tint = AccentCyan,
+                                modifier = Modifier.size(16.dp)
+                            )
+                        }
+                        IconButton(
+                            onClick = onDeleteStep,
+                            modifier = Modifier.size(28.dp)
+                        ) {
+                            Icon(
+                                imageVector = Icons.Default.Delete,
+                                contentDescription = "Delete step",
+                                tint = AccentRed,
+                                modifier = Modifier.size(16.dp)
+                            )
+                        }
+                    }
+
+                    // Step status icon
+                    Icon(
+                        imageVector = when (displayState) {
+                            StepDisplayState.COMPLETED -> Icons.Default.CheckCircle
+                            StepDisplayState.RUNNING -> Icons.Default.Refresh
+                            StepDisplayState.FAILED -> Icons.Default.Close
+                            StepDisplayState.AUTO_FIXING -> Icons.Default.Build
+                            StepDisplayState.REPAIRED -> Icons.Default.CheckCircle
+                            StepDisplayState.SKIPPED -> Icons.Default.ArrowForward
+                            StepDisplayState.BLOCKED -> Icons.Default.Warning
+                            StepDisplayState.PENDING -> Icons.Default.PlayArrow
+                        },
+                        contentDescription = displayState.name,
+                        tint = statusColor,
+                        modifier = Modifier.size(18.dp)
+                    )
+                }
             }
 
-            AnimatedVisibility(visible = expanded) {
+            AnimatedVisibility(visible = isEditing) {
+                Column(modifier = Modifier.padding(top = 12.dp)) {
+                    Divider(color = BorderColor, modifier = Modifier.padding(vertical = 4.dp))
+
+                    Text("Action Module: ${step.action}", fontSize = 11.sp, color = AccentPurple, fontFamily = FontFamily.Monospace)
+                    Spacer(modifier = Modifier.height(10.dp))
+
+                    OutlinedTextField(
+                        value = editDescription,
+                        onValueChange = { editDescription = it },
+                        label = { Text("Step Description", fontSize = 11.sp) },
+                        colors = OutlinedTextFieldDefaults.colors(
+                            focusedBorderColor = AccentNeonGreen,
+                            unfocusedBorderColor = BorderColor,
+                            focusedTextColor = TextPrimary,
+                            unfocusedTextColor = TextPrimary
+                        ),
+                        modifier = Modifier.fillMaxWidth()
+                    )
+
+                    Spacer(modifier = Modifier.height(10.dp))
+                    Text("Parameters", fontSize = 11.sp, color = TextSecondary)
+
+                    editParams.forEachIndexed { index, (key, value) ->
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(top = 6.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            OutlinedTextField(
+                                value = key,
+                                onValueChange = { newKey ->
+                                    editParams = editParams.toMutableList().also { it[index] = newKey to value }
+                                },
+                                label = { Text("Key", fontSize = 10.sp) },
+                                singleLine = true,
+                                colors = OutlinedTextFieldDefaults.colors(
+                                    focusedBorderColor = AccentNeonGreen,
+                                    unfocusedBorderColor = BorderColor,
+                                    focusedTextColor = TextPrimary,
+                                    unfocusedTextColor = TextPrimary
+                                ),
+                                modifier = Modifier.weight(1f)
+                            )
+                            Spacer(modifier = Modifier.width(6.dp))
+                            OutlinedTextField(
+                                value = value,
+                                onValueChange = { newValue ->
+                                    editParams = editParams.toMutableList().also { it[index] = key to newValue }
+                                },
+                                label = { Text("Value", fontSize = 10.sp) },
+                                singleLine = true,
+                                colors = OutlinedTextFieldDefaults.colors(
+                                    focusedBorderColor = AccentNeonGreen,
+                                    unfocusedBorderColor = BorderColor,
+                                    focusedTextColor = TextPrimary,
+                                    unfocusedTextColor = TextPrimary
+                                ),
+                                modifier = Modifier.weight(1f)
+                            )
+                            IconButton(
+                                onClick = { editParams = editParams.toMutableList().also { it.removeAt(index) } },
+                                modifier = Modifier.size(28.dp)
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Default.Close,
+                                    contentDescription = "Remove parameter",
+                                    tint = AccentRed,
+                                    modifier = Modifier.size(14.dp)
+                                )
+                            }
+                        }
+                    }
+
+                    TextButton(
+                        onClick = { editParams = editParams + ("" to "") },
+                        modifier = Modifier.padding(top = 4.dp)
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.Add,
+                            contentDescription = null,
+                            tint = AccentCyan,
+                            modifier = Modifier.size(14.dp)
+                        )
+                        Spacer(modifier = Modifier.width(4.dp))
+                        Text("Add Parameter", fontSize = 11.sp, color = AccentCyan)
+                    }
+
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.End
+                    ) {
+                        TextButton(onClick = { isEditing = false }) {
+                            Text("Cancel", color = TextSecondary)
+                        }
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Button(
+                            onClick = {
+                                val cleanedParams = editParams
+                                    .map { (k, v) -> k.trim() to v }
+                                    .filter { it.first.isNotEmpty() }
+                                    .toMap()
+                                val cleanedDescription = editDescription.trim().ifEmpty { step.description }
+                                onSaveEdit(cleanedDescription, cleanedParams)
+                                isEditing = false
+                            },
+                            colors = ButtonDefaults.buttonColors(containerColor = AccentNeonGreen, contentColor = DarkBackground),
+                            shape = RoundedCornerShape(8.dp)
+                        ) {
+                            Text("Save", fontWeight = FontWeight.Bold, fontSize = 12.sp)
+                        }
+                    }
+                }
+            }
+
+            AnimatedVisibility(visible = expanded && !isEditing) {
                 Column(modifier = Modifier.padding(top = 12.dp)) {
                     Divider(color = BorderColor, modifier = Modifier.padding(vertical = 4.dp))
                     

--- a/app/src/main/java/com/opendroid/ai/ui/screens/ChatScreen.kt
+++ b/app/src/main/java/com/opendroid/ai/ui/screens/ChatScreen.kt
@@ -14,11 +14,19 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.Forum
 import androidx.compose.material.icons.filled.Send
 import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material3.*
@@ -40,6 +48,7 @@ import androidx.core.content.ContextCompat
 import com.opendroid.ai.core.agent.AgentState
 import com.opendroid.ai.core.voice.SpeechRecognitionEngine
 import com.opendroid.ai.data.models.ChatMessage
+import com.opendroid.ai.data.repository.ChatSession
 import com.opendroid.ai.ui.components.ContactPickerCard
 import com.opendroid.ai.ui.theme.*
 import com.opendroid.ai.ui.viewmodel.ChatViewModel
@@ -58,15 +67,80 @@ fun ChatScreen(
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
     val history by viewModel.conversationHistory.collectAsState()
-    val agentState by viewModel.agentState.collectAsState()
-    
+    // Scoped to whichever chat is on screen right now - a task that's actually running
+    // in a DIFFERENT chat (safe since the pinned-session fix: it keeps writing there,
+    // not wherever the user has navigated to) must never be displayed as if it were
+    // happening here. See ChatViewModel.visibleAgentState.
+    val visibleAgentState by viewModel.visibleAgentState.collectAsState()
+    // Id of whichever chat (if any) has a task actively running, regardless of which
+    // chat is currently displayed - drives the chat-picker's "still running" indicator.
+    val runningSessionId by viewModel.runningSessionId.collectAsState()
+    val sessions by viewModel.sessions.collectAsState()
+    val currentSessionId = sessions.firstOrNull { it.isCurrent }?.id
+    val runningElsewhere = runningSessionId != null && runningSessionId != currentSessionId
+
     val listState = rememberLazyListState()
     var inputQuery by remember { mutableStateOf("") }
     var isListening by remember { mutableStateOf(false) }
     var transcriptionText by remember { mutableStateOf("") }
+    var voiceError by remember { mutableStateOf<String?>(null) }
+    var showChatMenu by remember { mutableStateOf(false) }
+    var sessionPendingDelete by remember { mutableStateOf<ChatSession?>(null) }
+    var sessionPendingRename by remember { mutableStateOf<ChatSession?>(null) }
+    var renameText by remember { mutableStateOf("") }
+    var editingMessageId by remember { mutableStateOf<String?>(null) }
+    var textBeforeEdit by remember { mutableStateOf("") }
 
-    // Scroll to bottom on history change
-    LaunchedEffect(history.size, agentState) {
+    // Merges a piece of dictated text into whatever the user already typed, so review/edit
+    // never clobbers text entered before dictation started.
+    fun mergeDictatedText(newText: String) {
+        if (newText.isBlank()) return
+        inputQuery = if (inputQuery.isBlank()) {
+            newText
+        } else {
+            inputQuery.trimEnd() + " " + newText.trimStart()
+        }
+    }
+
+    // Loads a previously sent user message into the input field for editing, remembering
+    // whatever was already typed so cancelling the edit can restore it untouched.
+    fun startEditingMessage(message: ChatMessage) {
+        if (editingMessageId == null) {
+            textBeforeEdit = inputQuery
+        }
+        editingMessageId = message.id
+        inputQuery = message.text
+    }
+
+    // Restores the input to whatever it held before the edit started; the conversation
+    // itself is never touched until a resend is actually submitted.
+    fun cancelEditingMessage() {
+        editingMessageId = null
+        inputQuery = textBeforeEdit
+        textBeforeEdit = ""
+    }
+
+    // Single submit path for both a normal send and an edit-resend, wired to both the
+    // keyboard "Send" action and the send button below.
+    fun submitInput() {
+        val text = inputQuery
+        if (text.isBlank()) return
+        val editing = editingMessageId
+        if (editing != null) {
+            viewModel.editAndResend(editing, text, context)
+            editingMessageId = null
+            textBeforeEdit = ""
+        } else {
+            viewModel.sendMessage(text, context)
+        }
+        inputQuery = ""
+    }
+
+    // Scroll to bottom on history change. Keyed on currentSessionId too: keying on
+    // history.size alone left the scroll position from the PREVIOUS chat in place
+    // whenever the newly switched-to chat happened to have the same message count -
+    // including currentSessionId forces a re-anchor to the bottom on every chat switch.
+    LaunchedEffect(currentSessionId, history.size, visibleAgentState) {
         if (history.isNotEmpty()) {
             listState.animateScrollToItem(history.size - 1)
         }
@@ -79,11 +153,12 @@ fun ChatScreen(
     ) { isGranted ->
         if (isGranted) {
             isListening = true
+            voiceError = null
+            transcriptionText = ""
             speechRecognizer.startListening(
                 onResult = { text ->
                     isListening = false
-                    inputQuery = text
-                    viewModel.sendMessage(text, context)
+                    mergeDictatedText(text)
                     transcriptionText = ""
                 },
                 onPartialResult = { partial ->
@@ -91,7 +166,9 @@ fun ChatScreen(
                 },
                 onError = { err ->
                     isListening = false
+                    mergeDictatedText(transcriptionText)
                     transcriptionText = ""
+                    voiceError = err
                 }
             )
         }
@@ -116,10 +193,114 @@ fun ChatScreen(
                             fontSize = 20.sp,
                             letterSpacing = 2.sp
                         )
-                        AgentStatusSubtitle(agentState)
+                        AgentStatusSubtitle(visibleAgentState, runningElsewhere)
                     }
                 },
                 actions = {
+                    IconButton(onClick = { viewModel.newChat() }) {
+                        Icon(
+                            imageVector = Icons.Default.Add,
+                            contentDescription = "New chat",
+                            tint = TextSecondary
+                        )
+                    }
+                    Box {
+                        IconButton(onClick = { showChatMenu = true }) {
+                            Icon(
+                                imageVector = Icons.Default.Forum,
+                                contentDescription = "Chats",
+                                tint = TextSecondary
+                            )
+                        }
+                        DropdownMenu(
+                            expanded = showChatMenu,
+                            onDismissRequest = { showChatMenu = false },
+                            modifier = Modifier.background(DarkSurface)
+                        ) {
+                            if (sessions.isEmpty()) {
+                                DropdownMenuItem(
+                                    text = { Text("No chats yet", color = TextSecondary, fontSize = 13.sp) },
+                                    onClick = {},
+                                    enabled = false
+                                )
+                            }
+                            sessions.forEach { session ->
+                                DropdownMenuItem(
+                                    text = {
+                                        Row(verticalAlignment = Alignment.CenterVertically) {
+                                            Text(
+                                                text = session.title,
+                                                color = if (session.isCurrent) AccentNeonGreen else TextPrimary,
+                                                fontWeight = if (session.isCurrent) FontWeight.Bold else FontWeight.Normal,
+                                                fontSize = 13.sp,
+                                                maxLines = 1
+                                            )
+                                            // Small "still running" dot: a task can now keep
+                                            // executing in a chat the user has switched away
+                                            // from, so this is the only place that fact is
+                                            // visible once its row scrolls out of the top bar.
+                                            if (runningSessionId == session.id) {
+                                                Spacer(modifier = Modifier.width(6.dp))
+                                                Box(
+                                                    modifier = Modifier
+                                                        .size(6.dp)
+                                                        .clip(CircleShape)
+                                                        .background(AccentNeonGreen)
+                                                )
+                                            }
+                                        }
+                                    },
+                                    leadingIcon = if (session.isCurrent) {
+                                        {
+                                            Icon(
+                                                imageVector = Icons.Default.Check,
+                                                contentDescription = null,
+                                                tint = AccentNeonGreen,
+                                                modifier = Modifier.size(16.dp)
+                                            )
+                                        }
+                                    } else null,
+                                    trailingIcon = {
+                                        Row(verticalAlignment = Alignment.CenterVertically) {
+                                            IconButton(
+                                                onClick = {
+                                                    renameText = session.title
+                                                    sessionPendingRename = session
+                                                    showChatMenu = false
+                                                },
+                                                modifier = Modifier.size(32.dp)
+                                            ) {
+                                                Icon(
+                                                    imageVector = Icons.Default.Edit,
+                                                    contentDescription = "Rename chat",
+                                                    tint = TextSecondary,
+                                                    modifier = Modifier.size(16.dp)
+                                                )
+                                            }
+                                            IconButton(
+                                                onClick = {
+                                                    sessionPendingDelete = session
+                                                    showChatMenu = false
+                                                },
+                                                modifier = Modifier.size(32.dp)
+                                            ) {
+                                                Icon(
+                                                    imageVector = Icons.Default.Delete,
+                                                    contentDescription = "Delete chat",
+                                                    tint = AccentRed,
+                                                    modifier = Modifier.size(16.dp)
+                                                )
+                                            }
+                                        }
+                                    },
+                                    onClick = {
+                                        showChatMenu = false
+                                        viewModel.switchToSession(session.id)
+                                    }
+                                )
+                            }
+                        }
+                    }
                     TextButton(onClick = { viewModel.clearChat() }) {
                         Text("Clear", color = TextSecondary, fontSize = 12.sp)
                     }
@@ -151,20 +332,28 @@ fun ChatScreen(
                     contentPadding = PaddingValues(top = 16.dp, bottom = 16.dp)
                 ) {
                     items(history) { msg ->
-                        ChatBubble(msg, viewModel, context)
+                        ChatBubble(
+                            message = msg,
+                            viewModel = viewModel,
+                            context = context,
+                            onEditRequested = { startEditingMessage(it) }
+                        )
                     }
                     
-                    // Show a typing/thinking bubble if thinking
-                    if (agentState is AgentState.Thinking) {
+                    // Show a typing/thinking bubble if thinking - scoped to this chat, see
+                    // visibleAgentState.
+                    if (visibleAgentState is AgentState.Thinking) {
                         item {
                             ThinkingBubble()
                         }
                     }
                 }
 
-                // If agent proposed a plan, show a modal prompt to approve or reject
-                if (agentState is AgentState.PlanProposed) {
-                    val proposedPlan = (agentState as AgentState.PlanProposed).plan
+                // If agent proposed a plan for THIS chat, show a modal prompt to approve or
+                // reject. A plan proposed for a different chat must never surface here - the
+                // user could approve/reject the wrong chat's plan without realizing it.
+                if (visibleAgentState is AgentState.PlanProposed) {
+                    val proposedPlan = (visibleAgentState as AgentState.PlanProposed).plan
                     ProposedPlanPrompt(
                         goal = proposedPlan.goal,
                         stepsCount = proposedPlan.estimatedSteps,
@@ -188,134 +377,256 @@ fun ChatScreen(
                     )
                     .padding(16.dp)
             ) {
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    // Floating Orb for Speech
-                    FloatingOrb(
-                        isListening = isListening,
-                        agentState = agentState,
-                        onClick = {
-                            if (isListening) {
-                                speechRecognizer.stopListening()
-                                isListening = false
-                            } else {
-                                val audioPerm = ContextCompat.checkSelfPermission(
-                                    context,
-                                    Manifest.permission.RECORD_AUDIO
-                                )
-                                if (audioPerm == PackageManager.PERMISSION_GRANTED) {
-                                    isListening = true
-                                    transcriptionText = "Listening..."
-                                    speechRecognizer.startListening(
-                                        onResult = { text ->
-                                            isListening = false
-                                            viewModel.sendMessage(text, context)
-                                            transcriptionText = ""
-                                        },
-                                        onPartialResult = { partial ->
-                                            transcriptionText = partial
-                                        },
-                                        onError = { err ->
-                                            isListening = false
-                                            transcriptionText = ""
-                                        }
-                                    )
-                                } else {
-                                    recordAudioPermissionLauncher.launch(Manifest.permission.RECORD_AUDIO)
-                                }
-                            }
-                        }
-                    )
-
-                    Spacer(modifier = Modifier.width(12.dp))
-
-                    // Text Input Field / Voice Waveform Area
-                    Box(
-                        modifier = Modifier
-                            .weight(1f)
-                            .height(56.dp)
-                            .clip(RoundedCornerShape(28.dp))
-                            .background(CardBackground)
-                            .border(1.dp, BorderColor, RoundedCornerShape(28.dp))
-                            .padding(horizontal = 16.dp),
-                        contentAlignment = Alignment.CenterStart
-                    ) {
-                        if (isListening) {
-                            VoiceWaveform(text = transcriptionText)
-                        } else {
-                            TextField(
-                                value = inputQuery,
-                                onValueChange = { inputQuery = it },
-                                placeholder = { Text("Ask OpenDroid to run an autonomous task...", color = TextSecondary, fontSize = 14.sp) },
-                                colors = TextFieldDefaults.colors(
-                                    focusedContainerColor = Color.Transparent,
-                                    unfocusedContainerColor = Color.Transparent,
-                                    disabledContainerColor = Color.Transparent,
-                                    focusedIndicatorColor = Color.Transparent,
-                                    unfocusedIndicatorColor = Color.Transparent,
-                                    focusedTextColor = TextPrimary,
-                                    unfocusedTextColor = TextPrimary
-                                ),
-                                singleLine = true,
-                                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Send),
-                                keyboardActions = KeyboardActions(onSend = {
-                                    if (inputQuery.isNotBlank()) {
-                                        viewModel.sendMessage(inputQuery, context)
-                                        inputQuery = ""
-                                    }
-                                }),
-                                modifier = Modifier.fillMaxWidth()
+                Column(modifier = Modifier.fillMaxWidth()) {
+                    if (editingMessageId != null) {
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(start = 4.dp, bottom = 6.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Icon(
+                                imageVector = Icons.Default.Edit,
+                                contentDescription = null,
+                                tint = AccentCyan,
+                                modifier = Modifier.size(14.dp)
+                            )
+                            Spacer(modifier = Modifier.width(6.dp))
+                            Text(
+                                text = "Editing message",
+                                fontSize = 11.sp,
+                                color = AccentCyan,
+                                modifier = Modifier.weight(1f)
+                            )
+                            Icon(
+                                imageVector = Icons.Default.Close,
+                                contentDescription = "Cancel edit",
+                                tint = TextSecondary,
+                                modifier = Modifier
+                                    .size(16.dp)
+                                    .clickable { cancelEditingMessage() }
                             )
                         }
                     }
-
-                    if (!isListening && inputQuery.isNotBlank()) {
-                        Spacer(modifier = Modifier.width(8.dp))
-                        IconButton(
+                    if (voiceError != null) {
+                        Text(
+                            text = voiceError.orEmpty(),
+                            fontSize = 11.sp,
+                            color = AccentRed,
+                            modifier = Modifier.padding(start = 4.dp, bottom = 6.dp)
+                        )
+                    }
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        // Floating Orb for Speech
+                        FloatingOrb(
+                            isListening = isListening,
+                            agentState = visibleAgentState,
                             onClick = {
-                                viewModel.sendMessage(inputQuery, context)
-                                inputQuery = ""
-                            },
+                                if (isListening) {
+                                    // True cancel: no final result will be delivered for this
+                                    // session, so whatever partial transcript we already have is
+                                    // handed back to the input field instead of being lost.
+                                    speechRecognizer.cancel()
+                                    isListening = false
+                                    mergeDictatedText(transcriptionText)
+                                    transcriptionText = ""
+                                } else {
+                                    val audioPerm = ContextCompat.checkSelfPermission(
+                                        context,
+                                        Manifest.permission.RECORD_AUDIO
+                                    )
+                                    if (audioPerm == PackageManager.PERMISSION_GRANTED) {
+                                        isListening = true
+                                        voiceError = null
+                                        transcriptionText = ""
+                                        speechRecognizer.startListening(
+                                            onResult = { text ->
+                                                isListening = false
+                                                mergeDictatedText(text)
+                                                transcriptionText = ""
+                                            },
+                                            onPartialResult = { partial ->
+                                                transcriptionText = partial
+                                            },
+                                            onError = { err ->
+                                                isListening = false
+                                                mergeDictatedText(transcriptionText)
+                                                transcriptionText = ""
+                                                voiceError = err
+                                            }
+                                        )
+                                    } else {
+                                        recordAudioPermissionLauncher.launch(Manifest.permission.RECORD_AUDIO)
+                                    }
+                                }
+                            }
+                        )
+
+                        Spacer(modifier = Modifier.width(12.dp))
+
+                        // Text Input Field / Voice Waveform Area
+                        Box(
                             modifier = Modifier
-                                .size(48.dp)
-                                .clip(CircleShape)
-                                .background(AccentNeonGreen)
+                                .weight(1f)
+                                .heightIn(min = 56.dp, max = 120.dp)
+                                .clip(RoundedCornerShape(28.dp))
+                                .background(CardBackground)
+                                .border(1.dp, BorderColor, RoundedCornerShape(28.dp))
+                                .padding(horizontal = 16.dp),
+                            contentAlignment = Alignment.CenterStart
                         ) {
-                            Icon(
-                                imageVector = Icons.Default.Send,
-                                contentDescription = "Send",
-                                tint = DarkBackground
-                            )
+                            if (isListening) {
+                                VoiceWaveform(
+                                    text = transcriptionText,
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .verticalScroll(rememberScrollState())
+                                        .padding(vertical = 12.dp)
+                                )
+                            } else {
+                                TextField(
+                                    value = inputQuery,
+                                    onValueChange = { inputQuery = it; voiceError = null },
+                                    placeholder = { Text("Ask OpenDroid to run an autonomous task...", color = TextSecondary, fontSize = 14.sp) },
+                                    colors = TextFieldDefaults.colors(
+                                        focusedContainerColor = Color.Transparent,
+                                        unfocusedContainerColor = Color.Transparent,
+                                        disabledContainerColor = Color.Transparent,
+                                        focusedIndicatorColor = Color.Transparent,
+                                        unfocusedIndicatorColor = Color.Transparent,
+                                        focusedTextColor = TextPrimary,
+                                        unfocusedTextColor = TextPrimary
+                                    ),
+                                    singleLine = true,
+                                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Send),
+                                    keyboardActions = KeyboardActions(onSend = { submitInput() }),
+                                    modifier = Modifier.fillMaxWidth()
+                                )
+                            }
+                        }
+
+                        if (!isListening && inputQuery.isNotBlank()) {
+                            Spacer(modifier = Modifier.width(8.dp))
+                            IconButton(
+                                onClick = { submitInput() },
+                                modifier = Modifier
+                                    .size(48.dp)
+                                    .clip(CircleShape)
+                                    .background(AccentNeonGreen)
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Default.Send,
+                                    contentDescription = "Send",
+                                    tint = DarkBackground
+                                )
+                            }
                         }
                     }
                 }
             }
         }
     }
+
+    sessionPendingDelete?.let { session ->
+        AlertDialog(
+            onDismissRequest = { sessionPendingDelete = null },
+            containerColor = DarkSurface,
+            title = { Text("Delete chat?", color = TextPrimary) },
+            text = {
+                Text(
+                    "\"${session.title}\" and its messages will be permanently deleted.",
+                    color = TextSecondary
+                )
+            },
+            confirmButton = {
+                TextButton(onClick = {
+                    viewModel.deleteChat(session.id)
+                    sessionPendingDelete = null
+                }) {
+                    Text("Delete", color = AccentRed, fontWeight = FontWeight.Bold)
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { sessionPendingDelete = null }) {
+                    Text("Cancel", color = TextSecondary)
+                }
+            }
+        )
+    }
+
+    sessionPendingRename?.let { session ->
+        AlertDialog(
+            onDismissRequest = { sessionPendingRename = null },
+            containerColor = DarkSurface,
+            title = { Text("Rename chat", color = TextPrimary) },
+            text = {
+                TextField(
+                    value = renameText,
+                    onValueChange = { renameText = it },
+                    singleLine = true,
+                    colors = TextFieldDefaults.colors(
+                        focusedContainerColor = Color.Transparent,
+                        unfocusedContainerColor = Color.Transparent,
+                        focusedIndicatorColor = AccentNeonGreen,
+                        unfocusedIndicatorColor = BorderColor,
+                        focusedTextColor = TextPrimary,
+                        unfocusedTextColor = TextPrimary
+                    ),
+                    modifier = Modifier.fillMaxWidth()
+                )
+            },
+            confirmButton = {
+                TextButton(onClick = {
+                    viewModel.renameSession(session.id, renameText)
+                    sessionPendingRename = null
+                }) {
+                    Text("Save", color = AccentNeonGreen, fontWeight = FontWeight.Bold)
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { sessionPendingRename = null }) {
+                    Text("Cancel", color = TextSecondary)
+                }
+            }
+        )
+    }
 }
 
 @Composable
-fun AgentStatusSubtitle(state: AgentState) {
-    val text = when (state) {
-        is AgentState.Idle -> "Online & Ready"
-        is AgentState.Listening -> "Listening to voice input..."
-        is AgentState.Thinking -> "Analyzing intent & planning..."
-        is AgentState.PlanProposed -> "Requires Plan Approval"
-        is AgentState.ExecutingPlan -> "Executing: ${state.currentStepDesc}"
-        is AgentState.Speaking -> "Speaking: ${state.text.take(30)}..."
-        is AgentState.Error -> "Execution Error"
+fun AgentStatusSubtitle(state: AgentState, runningElsewhere: Boolean = false) {
+    // runningElsewhere means [state] has already been forced to Idle because the real
+    // activity belongs to a different chat (see ChatViewModel.visibleAgentState) - say
+    // so explicitly instead of showing a plain "Online & Ready" that would hide the
+    // fact that a task is still going in the background.
+    val text = if (runningElsewhere) {
+        "Online & Ready · Task running in another chat"
+    } else {
+        when (state) {
+            is AgentState.Idle -> "Online & Ready"
+            is AgentState.Listening -> "Listening to voice input..."
+            is AgentState.Thinking -> "Analyzing intent & planning..."
+            is AgentState.PlanProposed -> "Requires Plan Approval"
+            is AgentState.ExecutingPlan -> "Executing: ${state.currentStepDesc}"
+            is AgentState.Speaking -> "Speaking: ${state.text.take(30)}..."
+            is AgentState.Error -> "Execution Error"
+        }
     }
-    
-    val color = when (state) {
-        is AgentState.Idle -> AccentNeonGreen
-        is AgentState.Listening -> AccentRed
-        is AgentState.Thinking -> AccentPurple
-        is AgentState.PlanProposed -> AccentCyan
-        is AgentState.ExecutingPlan -> AccentNeonGreen
-        is AgentState.Speaking -> AccentCyan
-        is AgentState.Error -> AccentRed
+
+    val color = if (runningElsewhere) {
+        AccentPurple
+    } else {
+        when (state) {
+            is AgentState.Idle -> AccentNeonGreen
+            is AgentState.Listening -> AccentRed
+            is AgentState.Thinking -> AccentPurple
+            is AgentState.PlanProposed -> AccentCyan
+            is AgentState.ExecutingPlan -> AccentNeonGreen
+            is AgentState.Speaking -> AccentCyan
+            is AgentState.Error -> AccentRed
+        }
     }
 
     Text(
@@ -327,7 +638,12 @@ fun AgentStatusSubtitle(state: AgentState) {
 }
 
 @Composable
-fun ChatBubble(message: ChatMessage, viewModel: ChatViewModel? = null, context: android.content.Context? = null) {
+fun ChatBubble(
+    message: ChatMessage,
+    viewModel: ChatViewModel? = null,
+    context: android.content.Context? = null,
+    onEditRequested: ((ChatMessage) -> Unit)? = null
+) {
     val isAgent = message.sender == ChatMessage.Sender.AGENT
     val alignment = if (isAgent) Alignment.Start else Alignment.End
     val bubbleColor = if (isAgent) CardBackground else AccentPurple.copy(alpha = 0.25f)
@@ -418,13 +734,31 @@ fun ChatBubble(message: ChatMessage, viewModel: ChatViewModel? = null, context: 
                 )
                 
                 Spacer(modifier = Modifier.height(4.dp))
-                
-                Text(
-                    text = timeFormat.format(Date(message.timestamp)),
-                    fontSize = 9.sp,
-                    color = TextSecondary,
-                    modifier = Modifier.align(Alignment.End)
-                )
+
+                Row(
+                    modifier = Modifier.align(Alignment.End),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(6.dp)
+                ) {
+                    // Edit affordance: user messages only, never on agent replies or the
+                    // contact-picker card (which is always an agent message, so it's
+                    // already excluded by the isAgent check above never reaching here).
+                    if (!isAgent && onEditRequested != null) {
+                        Icon(
+                            imageVector = Icons.Default.Edit,
+                            contentDescription = "Edit message",
+                            tint = TextSecondary,
+                            modifier = Modifier
+                                .size(13.dp)
+                                .clickable { onEditRequested(message) }
+                        )
+                    }
+                    Text(
+                        text = timeFormat.format(Date(message.timestamp)),
+                        fontSize = 9.sp,
+                        color = TextSecondary
+                    )
+                }
             }
         }
     }
@@ -606,7 +940,7 @@ fun FloatingOrb(
 }
 
 @Composable
-fun VoiceWaveform(text: String) {
+fun VoiceWaveform(text: String, modifier: Modifier = Modifier) {
     val infiniteTransition = rememberInfiniteTransition(label = "waveform")
     val heightScale1 by infiniteTransition.animateFloat(
         initialValue = 4f,
@@ -637,8 +971,8 @@ fun VoiceWaveform(text: String) {
     )
 
     Row(
-        modifier = Modifier.fillMaxWidth(),
-        verticalAlignment = Alignment.CenterVertically
+        modifier = modifier,
+        verticalAlignment = Alignment.Top
     ) {
         Row(
             modifier = Modifier.width(60.dp),
@@ -652,12 +986,15 @@ fun VoiceWaveform(text: String) {
             Box(modifier = Modifier.width(4.dp).height(heightScale1.dp).clip(CircleShape).background(AccentRed))
         }
         Spacer(modifier = Modifier.width(8.dp))
+        // No maxLines cap - long dictation wraps across multiple lines and the container
+        // (see the input Box in ChatScreen) scrolls once it exceeds its bounded max height.
         Text(
             text = text,
             fontSize = 13.sp,
             color = TextPrimary,
             fontFamily = FontFamily.SansSerif,
-            maxLines = 1
+            lineHeight = 18.sp,
+            modifier = Modifier.weight(1f)
         )
     }
 }

--- a/app/src/main/java/com/opendroid/ai/ui/screens/OnboardingScreen.kt
+++ b/app/src/main/java/com/opendroid/ai/ui/screens/OnboardingScreen.kt
@@ -1,20 +1,11 @@
 package com.opendroid.ai.ui.screens
 
-import android.Manifest
-import android.os.Build
-import android.content.Context
-import android.content.Intent
-import android.content.pm.PackageManager
-import android.provider.Settings
-import androidx.activity.compose.rememberLauncherForActivityResult
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardActions
@@ -26,16 +17,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.core.content.ContextCompat
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.LifecycleEventObserver
 import com.opendroid.ai.ui.theme.*
 
 enum class OnboardingStage {
@@ -50,100 +37,29 @@ fun OnboardingScreen(onFinished: () -> Unit) {
     val context = LocalContext.current
     val sharedPrefs = remember { com.opendroid.ai.core.security.SecurePrefs.get(context) }
 
-    var stage by remember { mutableStateOf(OnboardingStage.INTRODUCTION) }
     var name by remember { mutableStateOf(sharedPrefs.getString("user_name", "") ?: "") }
     var dob by remember { mutableStateOf(sharedPrefs.getString("user_dob", "") ?: "") }
-    var showError by remember { mutableStateOf(false) }
-
-    // Core permissions status state
-    var recordAudioGranted by remember { mutableStateOf(checkPerm(context, Manifest.permission.RECORD_AUDIO)) }
-    var locationGranted by remember { mutableStateOf(checkPerm(context, Manifest.permission.ACCESS_FINE_LOCATION)) }
-    var smsGranted by remember { mutableStateOf(checkPerm(context, Manifest.permission.SEND_SMS)) }
-    var phoneGranted by remember { mutableStateOf(checkPerm(context, Manifest.permission.CALL_PHONE)) }
-    var contactsGranted by remember { mutableStateOf(checkPerm(context, Manifest.permission.READ_CONTACTS)) }
-    var calendarGranted by remember { mutableStateOf(checkPerm(context, Manifest.permission.READ_CALENDAR)) }
-    var cameraGranted by remember { mutableStateOf(checkPerm(context, Manifest.permission.CAMERA)) }
-    var notificationsGranted by remember {
+    var stage by remember {
         mutableStateOf(
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                checkPerm(context, Manifest.permission.POST_NOTIFICATIONS)
+            if (name.isNotBlank() && dob.isNotBlank()) {
+                OnboardingStage.PERMISSION_PROMPT
             } else {
-                true
+                OnboardingStage.INTRODUCTION
             }
         )
     }
-    var storageGranted by remember { mutableStateOf(hasStoragePermission(context)) }
-    var accessibilityGranted by remember { mutableStateOf(isAccessibilityServiceEnabled(context)) }
-    var writeSettingsGranted by remember { mutableStateOf(Settings.System.canWrite(context)) }
-
-    val lifecycleOwner = LocalLifecycleOwner.current
-    DisposableEffect(lifecycleOwner) {
-        val observer = LifecycleEventObserver { _, event ->
-            if (event == Lifecycle.Event.ON_RESUME) {
-                accessibilityGranted = isAccessibilityServiceEnabled(context)
-                recordAudioGranted = checkPerm(context, Manifest.permission.RECORD_AUDIO)
-                locationGranted = checkPerm(context, Manifest.permission.ACCESS_FINE_LOCATION)
-                smsGranted = checkPerm(context, Manifest.permission.SEND_SMS)
-                phoneGranted = checkPerm(context, Manifest.permission.CALL_PHONE)
-                contactsGranted = checkPerm(context, Manifest.permission.READ_CONTACTS)
-                calendarGranted = checkPerm(context, Manifest.permission.READ_CALENDAR)
-                cameraGranted = checkPerm(context, Manifest.permission.CAMERA)
-                notificationsGranted = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                    checkPerm(context, Manifest.permission.POST_NOTIFICATIONS)
-                } else {
-                    true
-                }
-                storageGranted = hasStoragePermission(context)
-                writeSettingsGranted = Settings.System.canWrite(context)
-            }
-        }
-        lifecycleOwner.lifecycle.addObserver(observer)
-        onDispose {
-            lifecycleOwner.lifecycle.removeObserver(observer)
-        }
-    }
-
-    val audioLauncher = rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) {
-        recordAudioGranted = it
-    }
-    val locationLauncher = rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) {
-        locationGranted = it
-    }
-    val smsLauncher = rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) {
-        smsGranted = it
-    }
-    val phoneLauncher = rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) {
-        phoneGranted = it
-    }
-    val contactsLauncher = rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) {
-        contactsGranted = it
-    }
-    val calendarLauncher = rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) {
-        calendarGranted = it
-    }
-    val cameraLauncher = rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) {
-        cameraGranted = it
-    }
-    val notificationsLauncher = rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) {
-        notificationsGranted = it
-    }
-    val legacyStorageLauncher = rememberLauncherForActivityResult(
-        ActivityResultContracts.RequestMultiplePermissions()
-    ) { permissions ->
-        storageGranted = permissions[Manifest.permission.READ_EXTERNAL_STORAGE] == true &&
-                permissions[Manifest.permission.WRITE_EXTERNAL_STORAGE] == true
-    }
+    var showError by remember { mutableStateOf(false) }
 
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { 
+                title = {
                     val titleText = when (stage) {
                         OnboardingStage.INTRODUCTION -> "About You"
                         OnboardingStage.PERMISSION_PROMPT -> "Permissions"
                         OnboardingStage.PERMISSIONS -> "Grant Permissions"
                     }
-                    Text(titleText, color = AccentNeonGreen, fontWeight = FontWeight.Bold) 
+                    Text(titleText, color = AccentNeonGreen, fontWeight = FontWeight.Bold)
                 },
                 colors = TopAppBarDefaults.topAppBarColors(containerColor = DarkBackground)
             )
@@ -181,66 +97,8 @@ fun OnboardingScreen(onFinished: () -> Unit) {
                 )
             }
             OnboardingStage.PERMISSIONS -> {
-                PermissionsPanelContent(
+                PermissionsPanel(
                     padding = padding,
-                    recordAudioGranted = recordAudioGranted,
-                    locationGranted = locationGranted,
-                    smsGranted = smsGranted,
-                    phoneGranted = phoneGranted,
-                    contactsGranted = contactsGranted,
-                    calendarGranted = calendarGranted,
-                    cameraGranted = cameraGranted,
-                    notificationsGranted = notificationsGranted,
-                    storageGranted = storageGranted,
-                    accessibilityGranted = accessibilityGranted,
-                    writeSettingsGranted = writeSettingsGranted,
-                    onAudioGrant = { audioLauncher.launch(Manifest.permission.RECORD_AUDIO) },
-                    onLocationGrant = { locationLauncher.launch(Manifest.permission.ACCESS_FINE_LOCATION) },
-                    onSmsPhoneGrant = {
-                        smsLauncher.launch(Manifest.permission.SEND_SMS)
-                        phoneLauncher.launch(Manifest.permission.CALL_PHONE)
-                    },
-                    onContactsCalendarGrant = {
-                        contactsLauncher.launch(Manifest.permission.READ_CONTACTS)
-                        calendarLauncher.launch(Manifest.permission.READ_CALENDAR)
-                    },
-                    onCameraGrant = { cameraLauncher.launch(Manifest.permission.CAMERA) },
-                    onNotificationsGrant = { notificationsLauncher.launch(Manifest.permission.POST_NOTIFICATIONS) },
-                    onWriteSettingsGrant = {
-                        val intent = Intent(Settings.ACTION_MANAGE_WRITE_SETTINGS).apply {
-                            data = android.net.Uri.parse("package:${context.packageName}")
-                            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                        }
-                        context.startActivity(intent)
-                    },
-                    onStorageGrant = {
-                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-                            try {
-                                val intent = Intent(Settings.ACTION_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION).apply {
-                                    data = android.net.Uri.parse("package:${context.packageName}")
-                                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                                }
-                                context.startActivity(intent)
-                            } catch (e: Exception) {
-                                val intent = Intent(Settings.ACTION_MANAGE_ALL_FILES_ACCESS_PERMISSION).apply {
-                                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                                }
-                                context.startActivity(intent)
-                            }
-                        } else {
-                            legacyStorageLauncher.launch(
-                                arrayOf(
-                                    Manifest.permission.READ_EXTERNAL_STORAGE,
-                                    Manifest.permission.WRITE_EXTERNAL_STORAGE
-                                )
-                            )
-                        }
-                    },
-                    onAccessibilityGrant = {
-                        context.startActivity(Intent(Settings.ACTION_ACCESSIBILITY_SETTINGS).apply {
-                            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                        })
-                    },
                     onFinished = {
                         sharedPrefs.edit().putBoolean("onboarding_completed", true).apply()
                         onFinished()
@@ -284,27 +142,27 @@ fun IntroductionPanel(
                 modifier = Modifier.size(120.dp)
             )
         }
-        
+
         Spacer(modifier = Modifier.height(24.dp))
-        
+
         Text(
             text = "Hello! I am OpenDroid",
             fontSize = 24.sp,
             fontWeight = FontWeight.Bold,
             color = TextPrimary
         )
-        
+
         Spacer(modifier = Modifier.height(12.dp))
-        
+
         Text(
             text = "Your open autonomous device assistant. Please introduce yourself so I can serve you personally.",
             fontSize = 14.sp,
             color = TextSecondary,
             textAlign = androidx.compose.ui.text.style.TextAlign.Center
         )
-        
+
         Spacer(modifier = Modifier.height(28.dp))
-        
+
         OutlinedTextField(
             value = name,
             onValueChange = onNameChange,
@@ -323,9 +181,9 @@ fun IntroductionPanel(
             keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next),
             modifier = Modifier.fillMaxWidth()
         )
-        
+
         Spacer(modifier = Modifier.height(16.dp))
-        
+
         OutlinedTextField(
             value = dob,
             onValueChange = onDobChange,
@@ -345,7 +203,7 @@ fun IntroductionPanel(
             keyboardActions = KeyboardActions(onDone = { onContinue() }),
             modifier = Modifier.fillMaxWidth()
         )
-        
+
         if (showError) {
             Spacer(modifier = Modifier.height(8.dp))
             Text(
@@ -355,9 +213,9 @@ fun IntroductionPanel(
                 fontWeight = FontWeight.SemiBold
             )
         }
-        
+
         Spacer(modifier = Modifier.height(32.dp))
-        
+
         Button(
             onClick = onContinue,
             modifier = Modifier.fillMaxWidth().height(50.dp),
@@ -396,18 +254,18 @@ fun PermissionPromptPanel(
                 modifier = Modifier.size(120.dp)
             )
         }
-        
+
         Spacer(modifier = Modifier.height(24.dp))
-        
+
         Text(
             text = "Permissions Setup",
             fontSize = 24.sp,
             fontWeight = FontWeight.Bold,
             color = TextPrimary
         )
-        
+
         Spacer(modifier = Modifier.height(16.dp))
-        
+
         Text(
             text = "Let's give me permission so I can serve you well",
             fontSize = 16.sp,
@@ -415,18 +273,18 @@ fun PermissionPromptPanel(
             color = AccentCyan,
             textAlign = androidx.compose.ui.text.style.TextAlign.Center
         )
-        
+
         Spacer(modifier = Modifier.height(12.dp))
-        
+
         Text(
             text = "To allow me to interact with your device, run commands, list files, and operate system features, some standard Android permissions are required.",
             fontSize = 14.sp,
             color = TextSecondary,
             textAlign = androidx.compose.ui.text.style.TextAlign.Center
         )
-        
+
         Spacer(modifier = Modifier.height(48.dp))
-        
+
         Button(
             onClick = onContinue,
             modifier = Modifier.fillMaxWidth().height(50.dp),
@@ -436,210 +294,4 @@ fun PermissionPromptPanel(
             Text("Grant Permissions", fontWeight = FontWeight.Bold, fontSize = 16.sp)
         }
     }
-}
-
-@Composable
-fun PermissionsPanelContent(
-    padding: PaddingValues,
-    recordAudioGranted: Boolean,
-    locationGranted: Boolean,
-    smsGranted: Boolean,
-    phoneGranted: Boolean,
-    contactsGranted: Boolean,
-    calendarGranted: Boolean,
-    cameraGranted: Boolean,
-    notificationsGranted: Boolean,
-    storageGranted: Boolean,
-    accessibilityGranted: Boolean,
-    writeSettingsGranted: Boolean,
-    onAudioGrant: () -> Unit,
-    onLocationGrant: () -> Unit,
-    onSmsPhoneGrant: () -> Unit,
-    onContactsCalendarGrant: () -> Unit,
-    onCameraGrant: () -> Unit,
-    onNotificationsGrant: () -> Unit,
-    onWriteSettingsGrant: () -> Unit,
-    onStorageGrant: () -> Unit,
-    onAccessibilityGrant: () -> Unit,
-    onFinished: () -> Unit
-) {
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(padding)
-            .padding(24.dp)
-    ) {
-        Text(
-            text = "Required Permissions",
-            fontSize = 22.sp,
-            fontWeight = FontWeight.Bold,
-            color = TextPrimary
-        )
-        Spacer(modifier = Modifier.height(8.dp))
-        Text(
-            text = "Configure permissions below to enable full autonomous features.",
-            fontSize = 13.sp,
-            color = TextSecondary
-        )
-        Spacer(modifier = Modifier.height(16.dp))
-
-        LazyColumn(
-            modifier = Modifier.weight(1f),
-            verticalArrangement = Arrangement.spacedBy(12.dp)
-        ) {
-            item {
-                PermissionCard(
-                    title = "Microphone",
-                    desc = "Needed for wake word and speech recognition.",
-                    granted = recordAudioGranted,
-                    onGrant = onAudioGrant
-                )
-            }
-            item {
-                PermissionCard(
-                    title = "Location",
-                    desc = "Needed to fetch weather, directions, and maps.",
-                    granted = locationGranted,
-                    onGrant = onLocationGrant
-                )
-            }
-            item {
-                PermissionCard(
-                    title = "SMS & Telephony",
-                    desc = "Needed to read and send messages, and place calls.",
-                    granted = smsGranted && phoneGranted,
-                    onGrant = onSmsPhoneGrant
-                )
-            }
-            item {
-                PermissionCard(
-                    title = "Contacts & Calendar",
-                    desc = "Needed to resolve recipient names and manage events.",
-                    granted = contactsGranted && calendarGranted,
-                    onGrant = onContactsCalendarGrant
-                )
-            }
-            item {
-                PermissionCard(
-                    title = "Camera",
-                    desc = "Needed for image input and vision capabilities.",
-                    granted = cameraGranted,
-                    onGrant = onCameraGrant
-                )
-            }
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                item {
-                    PermissionCard(
-                        title = "Notifications",
-                        desc = "Needed to post system notifications and service status.",
-                        granted = notificationsGranted,
-                        onGrant = onNotificationsGrant
-                    )
-                }
-            }
-            item {
-                PermissionCard(
-                    title = "Storage / Files Access",
-                    desc = "Needed for agent to list, read, write, and delete files.",
-                    granted = storageGranted,
-                    onGrant = onStorageGrant
-                )
-            }
-            item {
-                PermissionCard(
-                    title = "System Settings Control",
-                    desc = "Needed to adjust brightness, volume, and other system settings.",
-                    granted = writeSettingsGranted,
-                    onGrant = onWriteSettingsGrant
-                )
-            }
-            item {
-                PermissionCard(
-                    title = "Accessibility Service",
-                    desc = "Enables full agent screen automation (clicks & inputs).",
-                    granted = accessibilityGranted,
-                    onGrant = onAccessibilityGrant
-                )
-            }
-        }
-
-        Spacer(modifier = Modifier.height(16.dp))
-
-        Button(
-            onClick = onFinished,
-            modifier = Modifier.fillMaxWidth().height(50.dp),
-            colors = ButtonDefaults.buttonColors(containerColor = AccentNeonGreen, contentColor = DarkBackground),
-            shape = RoundedCornerShape(8.dp)
-        ) {
-            Text("Proceed to OpenDroid Agent", fontWeight = FontWeight.Bold, fontSize = 16.sp)
-        }
-    }
-}
-
-@Composable
-fun PermissionCard(
-    title: String,
-    desc: String,
-    granted: Boolean,
-    onGrant: () -> Unit
-) {
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .clip(RoundedCornerShape(12.dp))
-            .background(CardBackground)
-            .padding(16.dp),
-        horizontalArrangement = Arrangement.SpaceBetween,
-        verticalAlignment = Alignment.CenterVertically
-    ) {
-        Column(modifier = Modifier.weight(1f)) {
-            Text(title, fontSize = 16.sp, fontWeight = FontWeight.Bold, color = TextPrimary)
-            Spacer(modifier = Modifier.height(4.dp))
-            Text(desc, fontSize = 12.sp, color = TextSecondary)
-        }
-        Spacer(modifier = Modifier.width(16.dp))
-        Button(
-            onClick = onGrant,
-            colors = ButtonDefaults.buttonColors(
-                containerColor = if (granted) BorderColor else AccentNeonGreen,
-                contentColor = if (granted) TextSecondary else DarkBackground
-            ),
-            shape = RoundedCornerShape(8.dp)
-        ) {
-            Text(if (granted) "Granted" else "Grant", fontSize = 12.sp, fontWeight = FontWeight.Bold)
-        }
-    }
-}
-
-private fun checkPerm(context: Context, permission: String): Boolean {
-    return ContextCompat.checkSelfPermission(context, permission) == PackageManager.PERMISSION_GRANTED
-}
-
-private fun hasStoragePermission(context: Context): Boolean {
-    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-        android.os.Environment.isExternalStorageManager()
-    } else {
-        checkPerm(context, Manifest.permission.READ_EXTERNAL_STORAGE) &&
-                checkPerm(context, Manifest.permission.WRITE_EXTERNAL_STORAGE)
-    }
-}
-
-private fun isAccessibilityServiceEnabled(context: Context): Boolean {
-    if (com.opendroid.ai.accessibility.OpenDroidAccessibilityService.getInstance() != null) {
-        return true
-    }
-    val expectedComponentName = android.content.ComponentName(context, com.opendroid.ai.accessibility.OpenDroidAccessibilityService::class.java).flattenToString()
-    val enabledServices = Settings.Secure.getString(
-        context.contentResolver,
-        Settings.Secure.ENABLED_ACCESSIBILITY_SERVICES
-    ) ?: return false
-    val colonSplitter = android.text.TextUtils.SimpleStringSplitter(':')
-    colonSplitter.setString(enabledServices)
-    while (colonSplitter.hasNext()) {
-        val componentNameString = colonSplitter.next()
-        if (componentNameString.equals(expectedComponentName, ignoreCase = true)) {
-            return true
-        }
-    }
-    return false
 }

--- a/app/src/main/java/com/opendroid/ai/ui/screens/PermissionsScreen.kt
+++ b/app/src/main/java/com/opendroid/ai/ui/screens/PermissionsScreen.kt
@@ -1,0 +1,442 @@
+package com.opendroid.ai.ui.screens
+
+import android.Manifest
+import android.os.Build
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.provider.Settings
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.core.content.ContextCompat
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import com.opendroid.ai.ui.theme.*
+
+/**
+ * Settings entry point for the permissions panel. Reachable from Settings so a user who
+ * declined a permission during onboarding (or wants to grant a new one, e.g. Accessibility)
+ * has an in-app way back in, without needing to dig through system App Info.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PermissionsScreen(
+    onNavigateBack: () -> Unit
+) {
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text(
+                        text = "PERMISSIONS",
+                        fontFamily = FontFamily.Monospace,
+                        fontWeight = FontWeight.Bold,
+                        color = AccentNeonGreen,
+                        fontSize = 20.sp,
+                        letterSpacing = 2.sp
+                    )
+                },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(
+                            imageVector = Icons.Default.ArrowBack,
+                            contentDescription = "Back",
+                            tint = AccentNeonGreen
+                        )
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = DarkBackground)
+            )
+        },
+        containerColor = DarkBackground
+    ) { padding ->
+        PermissionsPanel(padding = padding, onFinished = null)
+    }
+}
+
+/**
+ * Stateful permissions panel shared by onboarding's PERMISSIONS stage and the Settings
+ * "Permissions" destination ([PermissionsScreen]). Owns live granted/not-granted state for
+ * microphone, location, SMS/telephony, contacts/calendar, camera, notifications, storage,
+ * write-settings, and accessibility, and refreshes that state whenever the screen resumes
+ * (e.g. returning from the system Settings app after toggling Accessibility or Storage access).
+ *
+ * @param onFinished non-null only for the onboarding flow: when set, a "Proceed to OpenDroid
+ *   Agent" button is rendered and invokes this to mark onboarding complete. When null (the
+ *   Settings entry point) no finish button is rendered - the caller supplies its own back
+ *   affordance instead.
+ */
+@Composable
+fun PermissionsPanel(
+    padding: PaddingValues,
+    onFinished: (() -> Unit)?
+) {
+    val context = LocalContext.current
+
+    // Core permissions status state
+    var recordAudioGranted by remember { mutableStateOf(checkPerm(context, Manifest.permission.RECORD_AUDIO)) }
+    var locationGranted by remember { mutableStateOf(checkPerm(context, Manifest.permission.ACCESS_FINE_LOCATION)) }
+    var smsGranted by remember { mutableStateOf(checkPerm(context, Manifest.permission.SEND_SMS)) }
+    var phoneGranted by remember { mutableStateOf(checkPerm(context, Manifest.permission.CALL_PHONE)) }
+    var contactsGranted by remember { mutableStateOf(checkPerm(context, Manifest.permission.READ_CONTACTS)) }
+    var calendarGranted by remember { mutableStateOf(checkPerm(context, Manifest.permission.READ_CALENDAR)) }
+    var cameraGranted by remember { mutableStateOf(checkPerm(context, Manifest.permission.CAMERA)) }
+    var notificationsGranted by remember {
+        mutableStateOf(
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                checkPerm(context, Manifest.permission.POST_NOTIFICATIONS)
+            } else {
+                true
+            }
+        )
+    }
+    var storageGranted by remember { mutableStateOf(hasStoragePermission(context)) }
+    var accessibilityGranted by remember { mutableStateOf(isAccessibilityServiceEnabled(context)) }
+    var writeSettingsGranted by remember { mutableStateOf(Settings.System.canWrite(context)) }
+
+    val lifecycleOwner = LocalLifecycleOwner.current
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME) {
+                accessibilityGranted = isAccessibilityServiceEnabled(context)
+                recordAudioGranted = checkPerm(context, Manifest.permission.RECORD_AUDIO)
+                locationGranted = checkPerm(context, Manifest.permission.ACCESS_FINE_LOCATION)
+                smsGranted = checkPerm(context, Manifest.permission.SEND_SMS)
+                phoneGranted = checkPerm(context, Manifest.permission.CALL_PHONE)
+                contactsGranted = checkPerm(context, Manifest.permission.READ_CONTACTS)
+                calendarGranted = checkPerm(context, Manifest.permission.READ_CALENDAR)
+                cameraGranted = checkPerm(context, Manifest.permission.CAMERA)
+                notificationsGranted = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                    checkPerm(context, Manifest.permission.POST_NOTIFICATIONS)
+                } else {
+                    true
+                }
+                storageGranted = hasStoragePermission(context)
+                writeSettingsGranted = Settings.System.canWrite(context)
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose {
+            lifecycleOwner.lifecycle.removeObserver(observer)
+        }
+    }
+
+    val audioLauncher = rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) {
+        recordAudioGranted = it
+    }
+    val locationLauncher = rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) {
+        locationGranted = it
+    }
+    val smsLauncher = rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) {
+        smsGranted = it
+    }
+    val phoneLauncher = rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) {
+        phoneGranted = it
+    }
+    val contactsLauncher = rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) {
+        contactsGranted = it
+    }
+    val calendarLauncher = rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) {
+        calendarGranted = it
+    }
+    val cameraLauncher = rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) {
+        cameraGranted = it
+    }
+    val notificationsLauncher = rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) {
+        notificationsGranted = it
+    }
+    val legacyStorageLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestMultiplePermissions()
+    ) { permissions ->
+        storageGranted = permissions[Manifest.permission.READ_EXTERNAL_STORAGE] == true &&
+                permissions[Manifest.permission.WRITE_EXTERNAL_STORAGE] == true
+    }
+
+    PermissionsPanelContent(
+        padding = padding,
+        recordAudioGranted = recordAudioGranted,
+        locationGranted = locationGranted,
+        smsGranted = smsGranted,
+        phoneGranted = phoneGranted,
+        contactsGranted = contactsGranted,
+        calendarGranted = calendarGranted,
+        cameraGranted = cameraGranted,
+        notificationsGranted = notificationsGranted,
+        storageGranted = storageGranted,
+        accessibilityGranted = accessibilityGranted,
+        writeSettingsGranted = writeSettingsGranted,
+        onAudioGrant = { audioLauncher.launch(Manifest.permission.RECORD_AUDIO) },
+        onLocationGrant = { locationLauncher.launch(Manifest.permission.ACCESS_FINE_LOCATION) },
+        onSmsPhoneGrant = {
+            smsLauncher.launch(Manifest.permission.SEND_SMS)
+            phoneLauncher.launch(Manifest.permission.CALL_PHONE)
+        },
+        onContactsCalendarGrant = {
+            contactsLauncher.launch(Manifest.permission.READ_CONTACTS)
+            calendarLauncher.launch(Manifest.permission.READ_CALENDAR)
+        },
+        onCameraGrant = { cameraLauncher.launch(Manifest.permission.CAMERA) },
+        onNotificationsGrant = { notificationsLauncher.launch(Manifest.permission.POST_NOTIFICATIONS) },
+        onWriteSettingsGrant = {
+            val intent = Intent(Settings.ACTION_MANAGE_WRITE_SETTINGS).apply {
+                data = android.net.Uri.parse("package:${context.packageName}")
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            }
+            context.startActivity(intent)
+        },
+        onStorageGrant = {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                try {
+                    val intent = Intent(Settings.ACTION_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION).apply {
+                        data = android.net.Uri.parse("package:${context.packageName}")
+                        addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                    }
+                    context.startActivity(intent)
+                } catch (e: Exception) {
+                    val intent = Intent(Settings.ACTION_MANAGE_ALL_FILES_ACCESS_PERMISSION).apply {
+                        addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                    }
+                    context.startActivity(intent)
+                }
+            } else {
+                legacyStorageLauncher.launch(
+                    arrayOf(
+                        Manifest.permission.READ_EXTERNAL_STORAGE,
+                        Manifest.permission.WRITE_EXTERNAL_STORAGE
+                    )
+                )
+            }
+        },
+        onAccessibilityGrant = {
+            context.startActivity(Intent(Settings.ACTION_ACCESSIBILITY_SETTINGS).apply {
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            })
+        },
+        onFinished = onFinished
+    )
+}
+
+@Composable
+fun PermissionsPanelContent(
+    padding: PaddingValues,
+    recordAudioGranted: Boolean,
+    locationGranted: Boolean,
+    smsGranted: Boolean,
+    phoneGranted: Boolean,
+    contactsGranted: Boolean,
+    calendarGranted: Boolean,
+    cameraGranted: Boolean,
+    notificationsGranted: Boolean,
+    storageGranted: Boolean,
+    accessibilityGranted: Boolean,
+    writeSettingsGranted: Boolean,
+    onAudioGrant: () -> Unit,
+    onLocationGrant: () -> Unit,
+    onSmsPhoneGrant: () -> Unit,
+    onContactsCalendarGrant: () -> Unit,
+    onCameraGrant: () -> Unit,
+    onNotificationsGrant: () -> Unit,
+    onWriteSettingsGrant: () -> Unit,
+    onStorageGrant: () -> Unit,
+    onAccessibilityGrant: () -> Unit,
+    onFinished: (() -> Unit)?
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(padding)
+            .padding(24.dp)
+    ) {
+        Text(
+            text = "Required Permissions",
+            fontSize = 22.sp,
+            fontWeight = FontWeight.Bold,
+            color = TextPrimary
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        Text(
+            text = "Configure permissions below to enable full autonomous features.",
+            fontSize = 13.sp,
+            color = TextSecondary
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+
+        LazyColumn(
+            modifier = Modifier.weight(1f),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            item {
+                PermissionCard(
+                    title = "Microphone",
+                    desc = "Needed for wake word and speech recognition.",
+                    granted = recordAudioGranted,
+                    onGrant = onAudioGrant
+                )
+            }
+            item {
+                PermissionCard(
+                    title = "Location",
+                    desc = "Needed to fetch weather, directions, and maps.",
+                    granted = locationGranted,
+                    onGrant = onLocationGrant
+                )
+            }
+            item {
+                PermissionCard(
+                    title = "SMS & Telephony",
+                    desc = "Needed to read and send messages, and place calls.",
+                    granted = smsGranted && phoneGranted,
+                    onGrant = onSmsPhoneGrant
+                )
+            }
+            item {
+                PermissionCard(
+                    title = "Contacts & Calendar",
+                    desc = "Needed to resolve recipient names and manage events.",
+                    granted = contactsGranted && calendarGranted,
+                    onGrant = onContactsCalendarGrant
+                )
+            }
+            item {
+                PermissionCard(
+                    title = "Camera",
+                    desc = "Needed for image input and vision capabilities.",
+                    granted = cameraGranted,
+                    onGrant = onCameraGrant
+                )
+            }
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                item {
+                    PermissionCard(
+                        title = "Notifications",
+                        desc = "Needed to post system notifications and service status.",
+                        granted = notificationsGranted,
+                        onGrant = onNotificationsGrant
+                    )
+                }
+            }
+            item {
+                PermissionCard(
+                    title = "Storage / Files Access",
+                    desc = "Needed for agent to list, read, write, and delete files.",
+                    granted = storageGranted,
+                    onGrant = onStorageGrant
+                )
+            }
+            item {
+                PermissionCard(
+                    title = "System Settings Control",
+                    desc = "Needed to adjust brightness, volume, and other system settings.",
+                    granted = writeSettingsGranted,
+                    onGrant = onWriteSettingsGrant
+                )
+            }
+            item {
+                PermissionCard(
+                    title = "Accessibility Service",
+                    desc = "Enables full agent screen automation (clicks & inputs).",
+                    granted = accessibilityGranted,
+                    onGrant = onAccessibilityGrant
+                )
+            }
+        }
+
+        if (onFinished != null) {
+            Spacer(modifier = Modifier.height(16.dp))
+
+            Button(
+                onClick = onFinished,
+                modifier = Modifier.fillMaxWidth().height(50.dp),
+                colors = ButtonDefaults.buttonColors(containerColor = AccentNeonGreen, contentColor = DarkBackground),
+                shape = RoundedCornerShape(8.dp)
+            ) {
+                Text("Proceed to OpenDroid Agent", fontWeight = FontWeight.Bold, fontSize = 16.sp)
+            }
+        }
+    }
+}
+
+@Composable
+fun PermissionCard(
+    title: String,
+    desc: String,
+    granted: Boolean,
+    onGrant: () -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(12.dp))
+            .background(CardBackground)
+            .padding(16.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(title, fontSize = 16.sp, fontWeight = FontWeight.Bold, color = TextPrimary)
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(desc, fontSize = 12.sp, color = TextSecondary)
+        }
+        Spacer(modifier = Modifier.width(16.dp))
+        Button(
+            onClick = onGrant,
+            colors = ButtonDefaults.buttonColors(
+                containerColor = if (granted) BorderColor else AccentNeonGreen,
+                contentColor = if (granted) TextSecondary else DarkBackground
+            ),
+            shape = RoundedCornerShape(8.dp)
+        ) {
+            Text(if (granted) "Granted" else "Grant", fontSize = 12.sp, fontWeight = FontWeight.Bold)
+        }
+    }
+}
+
+private fun checkPerm(context: Context, permission: String): Boolean {
+    return ContextCompat.checkSelfPermission(context, permission) == PackageManager.PERMISSION_GRANTED
+}
+
+private fun hasStoragePermission(context: Context): Boolean {
+    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+        android.os.Environment.isExternalStorageManager()
+    } else {
+        checkPerm(context, Manifest.permission.READ_EXTERNAL_STORAGE) &&
+                checkPerm(context, Manifest.permission.WRITE_EXTERNAL_STORAGE)
+    }
+}
+
+private fun isAccessibilityServiceEnabled(context: Context): Boolean {
+    if (com.opendroid.ai.accessibility.OpenDroidAccessibilityService.getInstance() != null) {
+        return true
+    }
+    val expectedComponentName = android.content.ComponentName(context, com.opendroid.ai.accessibility.OpenDroidAccessibilityService::class.java).flattenToString()
+    val enabledServices = Settings.Secure.getString(
+        context.contentResolver,
+        Settings.Secure.ENABLED_ACCESSIBILITY_SERVICES
+    ) ?: return false
+    val colonSplitter = android.text.TextUtils.SimpleStringSplitter(':')
+    colonSplitter.setString(enabledServices)
+    while (colonSplitter.hasNext()) {
+        val componentNameString = colonSplitter.next()
+        if (componentNameString.equals(expectedComponentName, ignoreCase = true)) {
+            return true
+        }
+    }
+    return false
+}

--- a/app/src/main/java/com/opendroid/ai/ui/screens/PlanScreen.kt
+++ b/app/src/main/java/com/opendroid/ai/ui/screens/PlanScreen.kt
@@ -76,11 +76,14 @@ fun PlanScreen(
         ) {
             // Main Section: Current Active Plan
             if (displayPlan != null) {
+                val isCurrentActivePlan = displayPlan!!.planId == currentPlan?.planId
+
                 item {
                     PlanHeaderCard(
                         plan = displayPlan!!,
-                        isCurrentActive = displayPlan!!.planId == currentPlan?.planId,
-                        onClearSelection = { selectedPlanId = null }
+                        isCurrentActive = isCurrentActivePlan,
+                        onClearSelection = { selectedPlanId = null },
+                        onStop = { viewModel.stopTask() }
                     )
                 }
 
@@ -95,8 +98,18 @@ fun PlanScreen(
                     )
                 }
 
-                items(displayPlan!!.steps) { step ->
-                    PlanStepCard(step = step)
+                items(displayPlan!!.steps, key = { it.stepId }) { step ->
+                    val isStepEditable = isCurrentActivePlan &&
+                        displayPlan!!.status == PlanStatus.RUNNING &&
+                        step.status == StepStatus.PENDING
+                    PlanStepCard(
+                        step = step,
+                        editable = isStepEditable,
+                        onSaveEdit = { description, params ->
+                            viewModel.editStep(step.stepId, description, params)
+                        },
+                        onDeleteStep = { viewModel.deleteStep(step.stepId) }
+                    )
                 }
             } else {
                 item {
@@ -135,7 +148,8 @@ fun PlanScreen(
 fun PlanHeaderCard(
     plan: Plan,
     isCurrentActive: Boolean,
-    onClearSelection: () -> Unit
+    onClearSelection: () -> Unit,
+    onStop: () -> Unit
 ) {
     Card(
         modifier = Modifier
@@ -154,6 +168,7 @@ fun PlanHeaderCard(
                         PlanStatus.COMPLETED -> AccentNeonGreen
                         PlanStatus.RUNNING -> AccentCyan
                         PlanStatus.FAILED -> AccentRed
+                        PlanStatus.CANCELLED -> Color(0xFFFFB300) // Amber, matches PlanStepCard's in-between/warning states
                         else -> TextSecondary
                     }
                     Box(
@@ -219,6 +234,32 @@ fun PlanHeaderCard(
                 Column(horizontalAlignment = Alignment.End) {
                     Text("Estimated duration", fontSize = 10.sp, color = TextSecondary)
                     Text(plan.estimatedDuration, fontSize = 13.sp, fontWeight = FontWeight.Bold, color = TextPrimary)
+                }
+            }
+
+            if (isCurrentActive && plan.status == PlanStatus.RUNNING) {
+                Spacer(modifier = Modifier.height(12.dp))
+                Divider(color = BorderColor)
+                Spacer(modifier = Modifier.height(12.dp))
+                Button(
+                    onClick = onStop,
+                    colors = ButtonDefaults.buttonColors(containerColor = AccentRed, contentColor = TextPrimary),
+                    shape = RoundedCornerShape(8.dp),
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.Stop,
+                        contentDescription = null,
+                        modifier = Modifier.size(16.dp)
+                    )
+                    Spacer(modifier = Modifier.width(6.dp))
+                    Text(
+                        text = "STOP TASK",
+                        fontWeight = FontWeight.Bold,
+                        fontFamily = FontFamily.Monospace,
+                        fontSize = 12.sp,
+                        letterSpacing = 1.sp
+                    )
                 }
             }
         }
@@ -312,12 +353,14 @@ fun PastPlanRow(
                 imageVector = when (plan.status) {
                     PlanStatus.COMPLETED -> Icons.Default.Check
                     PlanStatus.FAILED -> Icons.Default.Close
+                    PlanStatus.CANCELLED -> Icons.Default.Cancel
                     else -> Icons.Default.Info
                 },
                 contentDescription = plan.status.name,
                 tint = when (plan.status) {
                     PlanStatus.COMPLETED -> AccentNeonGreen
                     PlanStatus.FAILED -> AccentRed
+                    PlanStatus.CANCELLED -> Color(0xFFFFB300) // Amber, matches PlanHeaderCard's CANCELLED color
                     else -> TextSecondary
                 },
                 modifier = Modifier.size(16.dp)

--- a/app/src/main/java/com/opendroid/ai/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/opendroid/ai/ui/screens/SettingsScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.material.icons.filled.KeyboardArrowRight
 import androidx.compose.material.icons.filled.KeyboardArrowUp
 import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material.icons.filled.Security
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -49,12 +50,9 @@ import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material.icons.filled.ArrowForward
-import androidx.compose.material.icons.filled.Visibility
-import androidx.compose.material.icons.filled.VisibilityOff
-import androidx.compose.ui.text.input.PasswordVisualTransformation
-import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.platform.LocalContext
 import android.content.Context
+import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -68,13 +66,15 @@ fun SettingsScreen(
     onNavigateToAbout: () -> Unit = {},
     onNavigateToAutoReply: () -> Unit = {},
     onNavigateToNotificationHistory: () -> Unit = {},
+    onNavigateToPermissions: () -> Unit = {},
     modifier: Modifier = Modifier
 ) {
     val config by viewModel.llmConfig.collectAsState()
     val dbModels by viewModel.allModels.collectAsState()
     val storageInfo by viewModel.storageInfo.collectAsState()
     val hfToken by viewModel.huggingFaceToken.collectAsState()
-    
+    val coroutineScope = rememberCoroutineScope()
+
     val providers = listOf(
         "Google Gemini",
         "OpenAI",
@@ -1594,6 +1594,52 @@ fun SettingsScreen(
                             Spacer(modifier = Modifier.height(2.dp))
                             Text(
                                 text = "View captured notifications and auto-reply log.",
+                                fontSize = 12.sp,
+                                color = TextSecondary
+                            )
+                        }
+                        Icon(
+                            imageVector = Icons.Default.KeyboardArrowRight,
+                            contentDescription = "Go",
+                            tint = TextSecondary
+                        )
+                    }
+                }
+            }
+
+            // Permissions link card
+            item {
+                Card(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .border(1.dp, AccentNeonGreen.copy(alpha = 0.3f), RoundedCornerShape(12.dp))
+                        .clickable { onNavigateToPermissions() },
+                    colors = CardDefaults.cardColors(containerColor = CardBackground)
+                ) {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(16.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.Security,
+                            contentDescription = "Permissions",
+                            tint = AccentNeonGreen,
+                            modifier = Modifier.size(24.dp)
+                        )
+                        Spacer(modifier = Modifier.width(12.dp))
+                        Column(modifier = Modifier.weight(1f)) {
+                            Text(
+                                text = "PERMISSIONS",
+                                fontSize = 11.sp,
+                                fontWeight = FontWeight.Bold,
+                                fontFamily = FontFamily.Monospace,
+                                color = AccentNeonGreen
+                            )
+                            Spacer(modifier = Modifier.height(2.dp))
+                            Text(
+                                text = "Review and grant microphone, storage, accessibility & other permissions.",
                                 fontSize = 12.sp,
                                 color = TextSecondary
                             )

--- a/app/src/main/java/com/opendroid/ai/ui/viewmodel/ChatViewModel.kt
+++ b/app/src/main/java/com/opendroid/ai/ui/viewmodel/ChatViewModel.kt
@@ -6,10 +6,13 @@ import androidx.lifecycle.viewModelScope
 import com.opendroid.ai.core.agent.AgentLoop
 import com.opendroid.ai.core.agent.AgentState
 import com.opendroid.ai.data.models.ChatMessage
+import com.opendroid.ai.data.repository.ChatSession
 import com.opendroid.ai.data.repository.ConversationRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -20,6 +23,9 @@ class ChatViewModel @Inject constructor(
     private val conversationRepository: ConversationRepository
 ) : ViewModel() {
 
+    // Scoped to whichever session is current; re-collects automatically when the
+    // user switches chats since the repository's flow is driven off the same
+    // reactive "current session" pointer that switchToSession() flips.
     val conversationHistory: StateFlow<List<ChatMessage>> = conversationRepository.conversations
         .stateIn(
             scope = viewModelScope,
@@ -27,14 +33,109 @@ class ChatViewModel @Inject constructor(
             initialValue = emptyList()
         )
 
+    /** Every chat session, most recently active first. */
+    val sessions: StateFlow<List<ChatSession>> = conversationRepository.sessions
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5000),
+            initialValue = emptyList()
+        )
+
+    /** Id of whichever session is current; null only before the very first session exists. */
+    val currentSessionId: StateFlow<String?> = conversationRepository.currentSessionId
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5000),
+            initialValue = null
+        )
+
     val agentState: StateFlow<AgentState> = agentLoop.agentState
+
+    // Session the most recently started task was pinned to. Set once, right when a task
+    // is kicked off (sendMessage for a genuinely new query, approvePlan, or
+    // editAndResend's resend) - mirroring AgentLoop's own "resolve the session once, at
+    // task start" rule so [agentState], which is a single field shared by every chat,
+    // can be attributed back to the chat it actually belongs to. See [visibleAgentState].
+    private val _taskSessionId = MutableStateFlow<String?>(null)
+
+    /**
+     * [agentState], but forced to [AgentState.Idle] whenever it actually describes a
+     * task pinned to a DIFFERENT chat than whichever one is current. Since a task now
+     * keeps running (and writing) in the chat it started in even after the user
+     * switches away, the shared [agentState] alone can't distinguish "busy in this
+     * chat" from "busy in some other chat" - this is what any UI representing the
+     * CURRENTLY VIEWED chat (thinking bubble, plan-approval prompt, orb pulse, status
+     * text) must read instead of [agentState] directly, or it would misattribute a
+     * background chat's activity to whatever the user happens to be looking at.
+     */
+    val visibleAgentState: StateFlow<AgentState> = combine(
+        agentState, _taskSessionId, sessions
+    ) { state, taskSessionId, sessionList ->
+        val current = sessionList.firstOrNull { it.isCurrent }?.id
+        if (taskSessionId == null || taskSessionId == current) state else AgentState.Idle
+    }.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(5000),
+        initialValue = AgentState.Idle
+    )
+
+    /**
+     * Id of whichever chat has an actively in-flight task (thinking or executing a plan
+     * step), or null when nothing is running anywhere. Unlike [visibleAgentState] this
+     * is NOT scoped to the currently viewed chat - it drives the chat-picker's "still
+     * running" indicator, which must stay visible for that chat even while the user has
+     * switched away from it.
+     */
+    val runningSessionId: StateFlow<String?> = combine(agentState, _taskSessionId) { state, sessionId ->
+        if (sessionId != null && (state is AgentState.Thinking || state is AgentState.ExecutingPlan)) {
+            sessionId
+        } else {
+            null
+        }
+    }.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(5000),
+        initialValue = null
+    )
+
+    // Snapshots which chat is current right now and records it as the session the next
+    // task will be pinned to. Reads the live-collected [sessions] snapshot for the same
+    // reason [isCurrentSession] does - [sessions] is guaranteed to be actively collected
+    // by ChatScreen, [currentSessionId] is not. Returns the same id so callers can pass
+    // it straight through to AgentLoop.processQuery instead of it re-resolving "current"
+    // itself at an arbitrary later moment.
+    private fun pinTaskSessionSnapshot(): String? {
+        val sessionId = sessions.value.firstOrNull { it.isCurrent }?.id
+        _taskSessionId.value = sessionId
+        return sessionId
+    }
 
     fun sendMessage(query: String, context: Context) {
         if (query.isBlank()) return
-        agentLoop.processQuery(query, context)
+        val sessionId = pinTaskSessionSnapshot()
+        agentLoop.processQuery(query, context, sessionId)
+    }
+
+    /**
+     * Edits a previously sent user message and resends it, DeepSeek-style: cancels any
+     * in-flight agent task first (so a running/awaiting-input task can never race with
+     * or swallow the resend), deletes that message and every message after it in the
+     * current session so the conversation visibly rewinds, then sends the edited text
+     * as a fresh query.
+     */
+    fun editAndResend(messageId: String, newText: String, context: Context) {
+        if (newText.isBlank()) return
+        agentLoop.cancelCurrentTask()
+        viewModelScope.launch {
+            val sessionId = conversationRepository.ensureCurrentSessionId()
+            conversationRepository.deleteMessageAndAfter(sessionId, messageId)
+            _taskSessionId.value = sessionId
+            agentLoop.processQuery(newText, context, sessionId)
+        }
     }
 
     fun approvePlan(context: Context) {
+        pinTaskSessionSnapshot()
         agentLoop.approveProposedPlan(context)
     }
 
@@ -42,9 +143,81 @@ class ChatViewModel @Inject constructor(
         agentLoop.rejectProposedPlan()
     }
 
+    /** Clears the messages of the CURRENT chat only - other chats are untouched. */
     fun clearChat() {
+        agentLoop.cancelCurrentTask()
         viewModelScope.launch {
-            conversationRepository.clearAll()
+            conversationRepository.clearCurrentSession()
         }
+    }
+
+    /**
+     * Starts a brand-new, empty chat and switches to it. Deliberately does NOT cancel
+     * whatever the agent is currently doing: since a task's session is pinned once at
+     * its start and threaded through explicitly, it keeps running - and keeps writing
+     * its replies - in the chat it was launched from, not wherever the user navigates
+     * to afterwards. [runningSessionId] / [visibleAgentState] are how the UI stays
+     * truthful about that chat still being busy while this one is not.
+     */
+    fun newChat() {
+        viewModelScope.launch {
+            conversationRepository.createSession()
+        }
+    }
+
+    /**
+     * Switches the active chat; [conversationHistory] re-collects for the new session.
+     * Deliberately does NOT cancel an in-flight task for the same reason [newChat] does
+     * not - see its doc comment.
+     */
+    fun switchToSession(sessionId: String) {
+        if (isCurrentSession(sessionId)) return
+        viewModelScope.launch {
+            conversationRepository.switchToSession(sessionId)
+        }
+    }
+
+    /** Renames a chat without changing which one is current. */
+    fun renameSession(sessionId: String, title: String) {
+        if (title.isBlank()) return
+        viewModelScope.launch {
+            conversationRepository.renameSession(sessionId, title.trim())
+        }
+    }
+
+    /**
+     * Deletes a chat and its messages. If it was the currently open chat, OR it is
+     * whichever chat [runningSessionId] says has a task actively writing into it right
+     * now, that task is cancelled first - deleting it out from under a still-running
+     * task would otherwise leave that task writing into a session that no longer
+     * exists. The repository guarantees another session becomes current - the user is
+     * never left with no chat selected.
+     */
+    fun deleteChat(sessionId: String) {
+        if (isCurrentSession(sessionId) || runningSessionId.value == sessionId) {
+            agentLoop.cancelCurrentTask()
+        }
+        agentLoop.forgetSession(sessionId)
+        viewModelScope.launch {
+            conversationRepository.deleteSession(sessionId)
+            conversationRepository.ensureCurrentSessionId()
+        }
+    }
+
+    // Reads the live-collected [sessions] snapshot rather than [currentSessionId].value:
+    // currentSessionId is exposed for callers that actually collect it, but nothing in
+    // this ViewModel guarantees it is being collected, and an un-collected
+    // WhileSubscribed StateFlow never advances past its initial value. [sessions] is
+    // always actively collected by ChatScreen (it drives the chat picker itself), so by
+    // the time a user can tap switch/delete on a session row, its value is current.
+    private fun isCurrentSession(sessionId: String): Boolean =
+        sessions.value.any { it.id == sessionId && it.isCurrent }
+
+    /**
+     * Cancels whatever the agent is currently doing without touching the
+     * conversation history. Shared by the Plan tab and the chat UI's stop control.
+     */
+    fun stopTask() {
+        agentLoop.cancelCurrentTask()
     }
 }

--- a/app/src/main/java/com/opendroid/ai/ui/viewmodel/PlanViewModel.kt
+++ b/app/src/main/java/com/opendroid/ai/ui/viewmodel/PlanViewModel.kt
@@ -2,6 +2,7 @@ package com.opendroid.ai.ui.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.opendroid.ai.core.agent.AgentLoop
 import com.opendroid.ai.core.agent.PlanManager
 import com.opendroid.ai.data.models.Plan
 import com.opendroid.ai.data.repository.PlanRepository
@@ -15,7 +16,8 @@ import javax.inject.Inject
 @HiltViewModel
 class PlanViewModel @Inject constructor(
     private val planManager: PlanManager,
-    private val planRepository: PlanRepository
+    private val planRepository: PlanRepository,
+    private val agentLoop: AgentLoop
 ) : ViewModel() {
 
     val currentPlan: StateFlow<Plan?> = planManager.currentPlan
@@ -36,6 +38,43 @@ class PlanViewModel @Inject constructor(
     fun deletePlan(planId: String) {
         viewModelScope.launch {
             planRepository.deletePlan(planId)
+        }
+    }
+
+    /**
+     * Cancels whatever the agent is currently doing (a running plan or an
+     * in-flight query) without touching conversation history. Backs the
+     * Plan tab's stop control - the Composable never talks to AgentLoop
+     * directly.
+     */
+    fun stopTask() {
+        agentLoop.cancelCurrentTask()
+    }
+
+    /**
+     * Edits the description and params of a step that has not started
+     * executing yet. Persisted atomically through PlanManager.updateStep,
+     * which no-ops if the step is no longer PENDING by the time this runs.
+     * Must not be split into separate updateStepDescription/updateStepParams
+     * calls - each acquires PlanManager's mutex independently, leaving a
+     * window where a concurrent reader (e.g. executePlanLoop's
+     * getStepSnapshot) can observe the new description paired with the old
+     * params.
+     */
+    fun editStep(stepId: String, description: String, params: Map<String, String>) {
+        viewModelScope.launch {
+            planManager.updateStep(stepId, description, params)
+        }
+    }
+
+    /**
+     * Removes a step that has not started executing yet from the current
+     * plan. Persisted through PlanManager, which no-ops if the step is no
+     * longer PENDING by the time this runs.
+     */
+    fun deleteStep(stepId: String) {
+        viewModelScope.launch {
+            planManager.removeStep(stepId)
         }
     }
 }


### PR DESCRIPTION
## Summary
- Extract permissions UI into a dedicated `PermissionsScreen`/`PermissionsPanel` so users can grant/revisit permissions from Settings after declining them during onboarding
- Harden agent loop, planning, chat sessions, and automation retries (cold-start UI polling) so multi-step actions and conversations are more reliable
- Add supporting chat-session DB pieces and URL helpers used by the above flows

## Test plan
- [ ] Fresh install: complete onboarding and verify permissions stage still works
- [ ] Decline a permission during onboarding, then open Settings → Permissions and grant it
- [ ] Navigate Settings → About and confirm About screen still opens cleanly
- [ ] Run a multi-step automation that opens an app then taps UI (verify retry waits for cold start)
- [ ] Start/switch chat sessions and confirm messages persist across navigation

Made with [Cursor](https://cursor.com)