### PR TITLE
fix: prevent native force close when prompt overflows on-device model context

### DIFF
--- a/app/src/main/java/com/opendroid/ai/core/llm/OnDeviceModelRegistry.kt
+++ b/app/src/main/java/com/opendroid/ai/core/llm/OnDeviceModelRegistry.kt
@@ -51,7 +51,13 @@ data class OnDeviceModelSpec(
     /** Whether this model is the recommended default for its backend. */
     val isRecommended: Boolean = false,
     /** Minimum Android SDK level required by this model variant. */
-    val minSdk: Int = 26
+    val minSdk: Int = 26,
+    /**
+     * Total token capacity (input + output) of the model's KV cache, e.g. 1280
+     * for a `...ekv1280.task` file. The LiteRT engine's `maxNumTokens` must be
+     * sized from this — exceeding it crashes natively.
+     */
+    val contextWindow: Int = 1280
 )
 
 /**
@@ -98,7 +104,8 @@ object OnDeviceModelRegistry {
             licenseUrl = "https://huggingface.co/litert-community/gemma-4-E2B-it-litert-lm",
             authRequired = true,
             isRecommended = true,
-            minSdk = 31
+            minSdk = 31,
+            contextWindow = 4096
         ),
         OnDeviceModelSpec(
             id = "gemma-4-e4b-it-litert",
@@ -111,7 +118,8 @@ object OnDeviceModelRegistry {
             expectedSize = 3660000000L,
             licenseUrl = "https://huggingface.co/litert-community/gemma-4-E4B-it-litert-lm",
             authRequired = true,
-            minSdk = 31
+            minSdk = 31,
+            contextWindow = 4096
         ),
         OnDeviceModelSpec(
             id = "gemma-3n-e2b-it-litert",
@@ -124,7 +132,8 @@ object OnDeviceModelRegistry {
             expectedSize = 2000000000L,  // TODO: Replace with actual published artifact size
             licenseUrl = "https://huggingface.co/google/gemma-3n-E2B-it-litert-lm",
             authRequired = true,
-            minSdk = 31
+            minSdk = 31,
+            contextWindow = 4096
         ),
         OnDeviceModelSpec(
             id = "gemma-3n-e4b-it-litert",
@@ -137,7 +146,8 @@ object OnDeviceModelRegistry {
             expectedSize = 4000000000L,  // TODO: Replace with actual published artifact size
             licenseUrl = "https://huggingface.co/google/gemma-3n-E4B-it-litert-lm",
             authRequired = true,
-            minSdk = 31
+            minSdk = 31,
+            contextWindow = 4096
         ),
         OnDeviceModelSpec(
             id = "qwen-2.5-0.5b-it-litert",
@@ -151,7 +161,8 @@ object OnDeviceModelRegistry {
             sha256 = "e608953f169aeb1bd7b9155fec2559825e08453fc209b84eda3a781ed0452fd2",
             licenseUrl = "https://huggingface.co/Qwen/Qwen2.5-0.5B-Instruct",
             authRequired = false,
-            minSdk = 26
+            minSdk = 26,
+            contextWindow = 1280
         )
     )
 

--- a/app/src/main/java/com/opendroid/ai/core/llm/PromptBudget.kt
+++ b/app/src/main/java/com/opendroid/ai/core/llm/PromptBudget.kt
@@ -1,0 +1,36 @@
+package com.opendroid.ai.core.llm
+
+/**
+ * Token budgeting for on-device models with small, fixed context windows.
+ *
+ * LiteRT-LM engines abort natively (SIGABRT in liblitertlm_jni) when the prompt
+ * exceeds the engine's `maxNumTokens` / the model's KV-cache size — that kills
+ * the whole process as a force close, with no catchable exception. This object
+ * lets providers check the prompt against the model's context window *before*
+ * handing it to the native runtime, so oversized prompts surface as a normal
+ * error message instead of a crash.
+ */
+object PromptBudget {
+
+    /** Rough chars-per-token heuristic; deliberately conservative for safety. */
+    private const val CHARS_PER_TOKEN = 4
+
+    /** Smallest output allocation worth running inference for. */
+    const val MIN_OUTPUT_TOKENS = 64
+
+    /** Estimates the token count of [text], rounding up. */
+    fun estimateTokens(text: String): Int =
+        (text.length + CHARS_PER_TOKEN - 1) / CHARS_PER_TOKEN
+
+    /**
+     * Returns how many output tokens a request may use once [prompt] is loaded
+     * into a [contextWindow]-token context: [requestedOutputTokens] when there is
+     * room, clamped down to the remaining space otherwise, or `null` when fewer
+     * than [MIN_OUTPUT_TOKENS] would remain — i.e. the prompt is too long to run.
+     */
+    fun outputBudget(prompt: String, contextWindow: Int, requestedOutputTokens: Int): Int? {
+        val remaining = contextWindow - estimateTokens(prompt)
+        if (remaining < MIN_OUTPUT_TOKENS) return null
+        return minOf(requestedOutputTokens, remaining)
+    }
+}

--- a/app/src/main/java/com/opendroid/ai/core/llm/providers/LiteRTLMProvider.kt
+++ b/app/src/main/java/com/opendroid/ai/core/llm/providers/LiteRTLMProvider.kt
@@ -162,7 +162,7 @@ class LiteRTLMProvider @Inject constructor(
                         ?: emptyList()
                 )
 
-                val outputText = invokeLiteRTInference(modelPath, prompt, request.maxTokens, request.temperature)
+                val outputText = invokeLiteRTInference(modelPath, spec, prompt, request.maxTokens, request.temperature)
 
                 LLMResponse(
                     content = outputText,
@@ -192,8 +192,9 @@ class LiteRTLMProvider @Inject constructor(
                     ?: emptyList()
             )
 
-            val engine = getOrInitializeEngine(modelPath, request.maxTokens)
-            
+            checkPromptFits(prompt, spec, request.maxTokens)
+            val engine = getOrInitializeEngine(modelPath, spec)
+
             val samplerConfig = SamplerConfig(
                 topK = 40,
                 topP = 0.95,
@@ -232,7 +233,7 @@ class LiteRTLMProvider @Inject constructor(
             val systemPrompt = "You are an autonomous AI agent for Android."
             val prompt = buildPrompt(systemPrompt, messages, tools)
 
-            val result = invokeLiteRTInference(modelPath, prompt, 2000, 0.7f)
+            val result = invokeLiteRTInference(modelPath, spec, prompt, 2000, 0.7f)
             emit(StreamChunk.Content(result))
 
             // Attempt tool call extraction from JSON response
@@ -376,7 +377,7 @@ class LiteRTLMProvider @Inject constructor(
      * call through to the real engine.
      */
     @Synchronized
-    private fun getOrInitializeEngine(modelPath: String, maxTokens: Int): Engine {
+    private fun getOrInitializeEngine(modelPath: String, spec: OnDeviceModelSpec): Engine {
         if (cachedModelPath != modelPath) {
             Log.i(TAG, "[INIT FLOW] Active model path changed from '$cachedModelPath' to '$modelPath'. Resetting cached engine.")
             closeCachedEngine()
@@ -385,12 +386,16 @@ class LiteRTLMProvider @Inject constructor(
         var engine = cachedEngine
         if (engine == null) {
             verifyModelFileIntegrity(modelPath)
-            
-            Log.i(TAG, "[INIT FLOW] Configuring EngineConfig with path: $modelPath")
+
+            Log.i(TAG, "[INIT FLOW] Configuring EngineConfig with path: $modelPath, maxNumTokens: ${spec.contextWindow}")
+            // maxNumTokens is the TOTAL token capacity (input + output) of the
+            // engine. It must match the model's KV-cache size (spec.contextWindow),
+            // NOT a request's output-token budget — undersizing it makes the native
+            // runtime abort (force close) as soon as a prompt exceeds it.
             val config = EngineConfig(
                 modelPath = modelPath,
                 backend = Backend.CPU(), // Run on CPU for compatibility
-                maxNumTokens = maxTokens,
+                maxNumTokens = spec.contextWindow,
                 cacheDir = context.cacheDir.absolutePath
             )
             
@@ -409,14 +414,31 @@ class LiteRTLMProvider @Inject constructor(
         return engine
     }
 
+    /**
+     * Verifies the prompt fits the model's context window BEFORE handing it to
+     * the native runtime. LiteRT-LM aborts the whole process (native SIGABRT,
+     * not a catchable exception) when the prompt overflows the engine's token
+     * capacity — this guard turns that force close into a normal error message.
+     */
+    private fun checkPromptFits(prompt: String, spec: OnDeviceModelSpec, requestedMaxTokens: Int): Int {
+        return PromptBudget.outputBudget(prompt, spec.contextWindow, requestedMaxTokens)
+            ?: throw IllegalStateException(
+                "This conversation is too long for ${spec.displayName} " +
+                "(~${PromptBudget.estimateTokens(prompt)} tokens, limit ${spec.contextWindow}). " +
+                "Start a new chat, shorten the message, or switch to a larger model."
+            )
+    }
+
     @Synchronized
     private fun invokeLiteRTInference(
         modelPath: String,
+        spec: OnDeviceModelSpec,
         prompt: String,
         maxTokens: Int,
         temperature: Float
     ): String {
         try {
+            checkPromptFits(prompt, spec, maxTokens)
             // 1. Verify LiteRT library classes / static classpath integrity
             Log.i(TAG, "[INIT FLOW] [STEP 1/6] Verifying LiteRT SDK classes on classpath...")
             // Compiles statically with com.google.ai.edge.litertlm.*
@@ -442,7 +464,7 @@ class LiteRTLMProvider @Inject constructor(
             // 3 & 4. Verify options configuration & engine initialization
             Log.i(TAG, "[INIT FLOW] [STEP 3/6 & 4/6] Creating & Initializing Engine...")
             val engine = try {
-                getOrInitializeEngine(modelPath, maxTokens)
+                getOrInitializeEngine(modelPath, spec)
             } catch (e: LinkageError) {
                 Log.e(TAG, "[INIT FLOW] [FAILURE] JNI native library failed to load (liblitertlm_jni.so)", e)
                 throw UnsatisfiedLinkError("LiteRT JNI native library failed to load (liblitertlm_jni.so). Error: ${e.localizedMessage}")

--- a/app/src/test/java/com/opendroid/ai/core/llm/PromptBudgetTest.kt
+++ b/app/src/test/java/com/opendroid/ai/core/llm/PromptBudgetTest.kt
@@ -1,0 +1,67 @@
+package com.opendroid.ai.core.llm
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class PromptBudgetTest {
+
+    @Test
+    fun `estimateTokens uses 4 chars per token rounded up`() {
+        assertEquals(0, PromptBudget.estimateTokens(""))
+        assertEquals(1, PromptBudget.estimateTokens("hi"))
+        assertEquals(1, PromptBudget.estimateTokens("abcd"))
+        assertEquals(2, PromptBudget.estimateTokens("abcde"))
+        assertEquals(25, PromptBudget.estimateTokens("x".repeat(100)))
+    }
+
+    @Test
+    fun `outputBudget returns requested tokens when prompt leaves room`() {
+        // 100 chars ~= 25 tokens; context 1280 leaves plenty for 500 output tokens
+        val budget = PromptBudget.outputBudget(
+            prompt = "x".repeat(100),
+            contextWindow = 1280,
+            requestedOutputTokens = 500
+        )
+        assertEquals(500, budget)
+    }
+
+    @Test
+    fun `outputBudget clamps requested tokens to remaining context`() {
+        // 4000 chars ~= 1000 tokens; context 1280 leaves 280 for output
+        val budget = PromptBudget.outputBudget(
+            prompt = "x".repeat(4000),
+            contextWindow = 1280,
+            requestedOutputTokens = 1500
+        )
+        assertEquals(280, budget)
+    }
+
+    @Test
+    fun `outputBudget returns null when prompt fills the context window`() {
+        // 6000 chars ~= 1500 tokens > 1280 context: nothing left for output
+        val budget = PromptBudget.outputBudget(
+            prompt = "x".repeat(6000),
+            contextWindow = 1280,
+            requestedOutputTokens = 500
+        )
+        assertNull(budget)
+    }
+
+    @Test
+    fun `outputBudget returns null when remaining space is below the minimum useful output`() {
+        // 5000 chars ~= 1250 tokens; only 30 tokens left, below MIN_OUTPUT_TOKENS
+        val budget = PromptBudget.outputBudget(
+            prompt = "x".repeat(5000),
+            contextWindow = 1280,
+            requestedOutputTokens = 500
+        )
+        assertNull(budget)
+    }
+
+    @Test
+    fun `registry qwen spec carries its ekv1280 context window`() {
+        val qwen = OnDeviceModelRegistry.findById("qwen-2.5-0.5b-it-litert")!!
+        assertEquals(1280, qwen.contextWindow)
+    }
+}


### PR DESCRIPTION
Fixes #15

## Root cause

`LiteRTLMProvider` created the LiteRT engine with `maxNumTokens = request.maxTokens` — a request's *output* budget (500). In LiteRT-LM, `maxNumTokens` is the engine's **total** token capacity (input + output). The agent's system prompts (planning prompt + memory context + tool schemas + history) far exceed 500 tokens, and Qwen 2.5 0.5B's model file (`...ekv1280.task`) has only a 1280-token KV cache. When the prompt overflows, the native runtime aborts (SIGABRT in `liblitertlm_jni.so`) — no Kotlin `catch` can intercept it, so the process dies and the app force closes. This matches the report exactly: crash on send with Qwen-2.5.

Secondary bug: the engine is cached per model path, so the first request's undersized 500-token limit stuck for all subsequent requests.

## Fix

- `OnDeviceModelSpec` gains a `contextWindow` field (Qwen: 1280, Gemma LiteRT: 4096); the engine's `maxNumTokens` is now sized from the model spec, not the request
- New `PromptBudget` estimates prompt tokens (~4 chars/token) and clamps the output budget to the remaining context
- All three inference paths (`complete`, `streamComplete`, `generate`) check the prompt fits *before* handing it to the native runtime; an oversized prompt now throws a catchable `IllegalStateException` that surfaces as a friendly chat error ("This conversation is too long for … Start a new chat, shorten the message, or switch to a larger model.") instead of killing the app

## Testing

- New `PromptBudgetTest` (6 cases: estimation, clamping, overflow rejection, registry wiring)
- Full unit suite `:app:testDebugUnitTest`: 66 tests, 0 failures

## Known limitation

On a 1280-token model, long conversations or the planning path can legitimately exceed the context; users now get a clear error instead of a crash. Proper history truncation for small-context models is a good follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)