### PR TITLE
fix: crash on fresh install — microphone FGS started without RECORD_AUDIO

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -34,6 +34,7 @@
     <uses-permission android:name="android.permission.WAKE_LOCK"/>
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE"/>
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE"/>
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
     <uses-permission android:name="android.permission.USE_BIOMETRIC"/>
@@ -76,8 +77,12 @@
         <!-- Foreground Service for Wake-word and Speech processing -->
         <service
             android:name=".core.service.OpenDroidService"
-            android:foregroundServiceType="microphone"
-            android:exported="false" />
+            android:foregroundServiceType="microphone|specialUse"
+            android:exported="false">
+            <property
+                android:name="android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE"
+                android:value="Voice assistant agent loop; runs without microphone until the user grants RECORD_AUDIO" />
+        </service>
 
         <!-- Accessibility Service for System Automation -->
         <service

--- a/app/src/main/java/com/opendroid/ai/core/service/OpenDroidService.kt
+++ b/app/src/main/java/com/opendroid/ai/core/service/OpenDroidService.kt
@@ -75,7 +75,7 @@ class OpenDroidService : Service() {
 
         // Start Foreground Notification
         createNotificationChannel()
-        startForeground(NOTIFICATION_ID, createNotification())
+        startForegroundCompat()
 
         // Monitor floating button config to start/stop wake word detection dynamically
         serviceScope.launch {
@@ -87,6 +87,39 @@ class OpenDroidService : Service() {
                     startWakeWordDetection()
                 }
             }
+        }
+    }
+
+    private fun startForegroundCompat() {
+        val notification = createNotification()
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            // Starting a microphone-type FGS without RECORD_AUDIO granted throws a
+            // SecurityException on Android 14+, and starting one from BOOT_COMPLETED is
+            // prohibited on Android 15 even with the permission. Fall back to specialUse
+            // until the microphone is actually usable.
+            val micGranted = androidx.core.content.ContextCompat.checkSelfPermission(
+                this, android.Manifest.permission.RECORD_AUDIO
+            ) == android.content.pm.PackageManager.PERMISSION_GRANTED
+            val type = if (micGranted) {
+                android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE
+            } else {
+                android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_SPECIAL_USE
+            }
+            try {
+                androidx.core.app.ServiceCompat.startForeground(this, NOTIFICATION_ID, notification, type)
+            } catch (e: SecurityException) {
+                androidx.core.app.ServiceCompat.startForeground(
+                    this, NOTIFICATION_ID, notification,
+                    android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_SPECIAL_USE
+                )
+            }
+        } else if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.Q) {
+            androidx.core.app.ServiceCompat.startForeground(
+                this, NOTIFICATION_ID, notification,
+                android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE
+            )
+        } else {
+            startForeground(NOTIFICATION_ID, notification)
         }
     }
 


### PR DESCRIPTION
## Summary
- Fresh installs on Android 14+ crash-loop on first launch ("OpenDroid keeps stopping"): `OpenDroidService` calls `startForeground()` with manifest type `microphone` before the user has granted `RECORD_AUDIO`, which throws `SecurityException` on targetSDK 35
- Android 15 additionally prohibits microphone-type FGS starts from `BOOT_COMPLETED` even with the permission granted, so `BootReceiver` hits the same crash
- Fix: declare `specialUse` as a fallback foreground service type and choose the type at runtime — `microphone` when `RECORD_AUDIO` is granted, `specialUse` otherwise, with a `SecurityException` fallback for boot-time edge cases

Discovered while investigating #12 / #9 on an Android 15 emulator: crash reproduced instantly on every fresh install before any permission flow could run.

## Changes
- `AndroidManifest.xml`: service `foregroundServiceType` → `microphone|specialUse`, added `FOREGROUND_SERVICE_SPECIAL_USE` permission and `PROPERTY_SPECIAL_USE_FGS_SUBTYPE` property (required for Play review)
- `OpenDroidService.kt`: new `startForegroundCompat()` — API 34+ picks the FGS type by permission state via `ServiceCompat.startForeground`; API 29–33 keeps `MICROPHONE`; older APIs use plain `startForeground`

Note: until `RECORD_AUDIO` is granted the service runs as `specialUse`, so wake-word listening stays off; once the user grants the permission and the service restarts it promotes to `microphone` type.

## Test plan
- [x] Android 15 emulator (API 35), fresh install, zero permissions: app launches to onboarding, no crash, crash buffer clean
- [x] `dumpsys activity services` confirms `isForeground=true types=0x40000000` (SPECIAL_USE fallback active)
- [x] `:app:assembleDebug` builds clean
- [x] Emulator: grant microphone permission, restart app — service promotes to microphone type (`types=0x00000080` in dumpsys), no crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)
