### PR TITLE
feat: Add Auto mode (plan auto-approval and allowlist)

### DIFF
--- a/app/src/main/java/com/opendroid/ai/core/agent/ActionSchema.kt
+++ b/app/src/main/java/com/opendroid/ai/core/agent/ActionSchema.kt
@@ -6,7 +6,10 @@ data class ActionDefinition(
     val params: List<ParamDefinition>,
     val examples: List<String>,
     val category: ActionCategory,
-    val isSimple: Boolean = true
+    val isSimple: Boolean = true,
+    // Moves money or has irreversible/destructive consequence: always show the
+    // approval modal in Auto mode, never offer an "Always allow" grant.
+    val neverAutoApprove: Boolean = false
 )
 
 data class ParamDefinition(
@@ -194,7 +197,8 @@ object ActionSchema {
             params = emptyList(),
             examples = listOf("restart phone", "reboot device"),
             category = ActionCategory.SYSTEM,
-            isSimple = false
+            isSimple = false,
+            neverAutoApprove = true
         ),
         ActionDefinition(
             name = "SET_WALLPAPER",
@@ -215,7 +219,8 @@ object ActionSchema {
             description = "Opens Play Store to install an app",
             params = listOf(ParamDefinition("appName", ParamType.STRING, true, "App name to install")),
             examples = listOf("install telegram", "download app"),
-            category = ActionCategory.SYSTEM
+            category = ActionCategory.SYSTEM,
+            neverAutoApprove = true
         ),
         ActionDefinition(
             name = "GET_SYSTEM_INFO",
@@ -301,7 +306,8 @@ object ActionSchema {
             description = "Opens browser settings to clear browsing data (history, cache, cookies)",
             params = emptyList(),
             examples = listOf("clear browser history", "clear cache", "clear browsing data", "delete browser data"),
-            category = ActionCategory.SYSTEM
+            category = ActionCategory.SYSTEM,
+            neverAutoApprove = true
         ),
 
         // ── COMMUNICATION ───────────────────────────────
@@ -606,7 +612,8 @@ object ActionSchema {
                 ParamDefinition("rideType", ParamType.STRING, false, "Ride type")
             ),
             examples = listOf("book uber to airport", "get cab to office"),
-            category = ActionCategory.TRANSPORT
+            category = ActionCategory.TRANSPORT,
+            neverAutoApprove = true
         ),
         ActionDefinition(
             name = "BOOK_OLA",
@@ -617,7 +624,8 @@ object ActionSchema {
                 ParamDefinition("rideType", ParamType.STRING, false, "Ride type")
             ),
             examples = listOf("book ola to station", "ola cab to mall"),
-            category = ActionCategory.TRANSPORT
+            category = ActionCategory.TRANSPORT,
+            neverAutoApprove = true
         ),
         ActionDefinition(
             name = "GET_DIRECTIONS",
@@ -739,7 +747,8 @@ object ActionSchema {
             ),
             examples = listOf("order pizza", "order food from zomato"),
             category = ActionCategory.SHOPPING,
-            isSimple = false
+            isSimple = false,
+            neverAutoApprove = true
         ),
         ActionDefinition(
             name = "ORDER_GROCERY",
@@ -750,7 +759,8 @@ object ActionSchema {
             ),
             examples = listOf("order milk from blinkit", "buy groceries"),
             category = ActionCategory.SHOPPING,
-            isSimple = false
+            isSimple = false,
+            neverAutoApprove = true
         ),
         ActionDefinition(
             name = "SEARCH_AMAZON",
@@ -814,7 +824,8 @@ object ActionSchema {
             description = "Locks a smart door lock",
             params = listOf(ParamDefinition("location", ParamType.STRING, false, "Door location", defaultValue = "front door")),
             examples = listOf("lock the front door", "lock door"),
-            category = ActionCategory.SMART_HOME
+            category = ActionCategory.SMART_HOME,
+            neverAutoApprove = true
         ),
 
         // ── FINANCE ─────────────────────────────────────
@@ -830,7 +841,8 @@ object ActionSchema {
             ),
             examples = listOf("pay 500 to John", "send 200 rupees to dad"),
             category = ActionCategory.FINANCE,
-            isSimple = false
+            isSimple = false,
+            neverAutoApprove = true
         ),
         ActionDefinition(
             name = "CHECK_BALANCE",
@@ -915,7 +927,8 @@ object ActionSchema {
             params = listOf(ParamDefinition("filePath", ParamType.STRING, true, "File path to delete")),
             examples = listOf("delete file"),
             category = ActionCategory.ADVANCED,
-            isSimple = false
+            isSimple = false,
+            neverAutoApprove = true
         ),
         ActionDefinition(
             name = "CREATE_DIRECTORY",
@@ -1118,6 +1131,10 @@ object ActionSchema {
     /** Get simple actions (never need a plan) */
     fun getSimpleActions(): List<String> =
         ALL_ACTIONS.filter { it.isSimple }.map { it.name }
+
+    /** Check if action should never be auto-approved (moves money or irreversible) */
+    fun isNeverAutoApprove(actionName: String): Boolean =
+        ALL_ACTIONS.firstOrNull { it.name == actionName }?.neverAutoApprove ?: false
 
     /**
      * Build strict schema text for LLM prompt.

--- a/app/src/main/java/com/opendroid/ai/core/agent/AgentLoop.kt
+++ b/app/src/main/java/com/opendroid/ai/core/agent/AgentLoop.kt
@@ -8,11 +8,14 @@ import com.opendroid.ai.core.llm.LLMRequest
 import com.opendroid.ai.core.llm.ResponseFormat
 import com.opendroid.ai.core.llm.prompts.PlanningPrompts
 import com.opendroid.ai.core.memory.MemoryManager
+import com.opendroid.ai.data.models.AutoMode
 import com.opendroid.ai.data.models.ChatMessage
 import com.opendroid.ai.data.models.Plan
 import com.opendroid.ai.data.models.PlanStatus
 import com.opendroid.ai.data.models.PlanStep
 import com.opendroid.ai.data.models.StepStatus
+import com.opendroid.ai.data.models.effectiveGrantedActions
+import com.opendroid.ai.data.models.resolvedAutoMode
 import com.opendroid.ai.data.repository.ConversationRepository
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
@@ -542,8 +545,10 @@ class AgentLoop @Inject constructor(
             }
 
             planManager.startNewPlan(plan, context)
-            if (config.autoConfirmPlans) {
-                executePlanLoop(plan, context, sessionId)
+            val autoMode = config.resolvedAutoMode()
+            if (AutoApprovalPolicy.shouldAutoApprove(autoMode, config.effectiveGrantedActions().keys, plan)) {
+                recordAutoApprovedTrace(plan, autoMode, sessionId)
+                executePlanLoop(plan, context, sessionId, autoApproved = true)
             } else {
                 proposedPlanSessionId = sessionId
                 _agentState.value = AgentState.PlanProposed(plan)
@@ -589,9 +594,22 @@ class AgentLoop @Inject constructor(
         executeSimpleQuery(userMsg, sessionId)
     }
 
-    fun approveProposedPlan(context: Context) {
+    fun approveProposedPlan(context: Context, grantActions: Set<String> = emptySet()) {
         currentJob?.cancel()
         val job = scope.launch {
+            // "Always allow" checkboxes from the approval modal: persist BEFORE
+            // executing so a crash mid-plan can't lose an explicit user grant.
+            // Filter through isGrantable - neverAutoApprove actions can never
+            // enter the allowlist no matter what the UI sends.
+            val toGrant = grantActions.filter { AutoApprovalPolicy.isGrantable(it) }
+            if (toGrant.isNotEmpty()) {
+                val grantedAt = System.currentTimeMillis()
+                settingsRepository.updateConfig { current ->
+                    current.copy(
+                        grantedActions = current.effectiveGrantedActions() + toGrant.associateWith { grantedAt }
+                    )
+                }
+            }
             // Approving a proposed plan starts a new task in its own right (the plan may
             // have been proposed in an earlier, now-idle turn), so pin its session here too -
             // same rationale as processQuery, see activeTaskSessionId. Executes in the
@@ -740,7 +758,7 @@ class AgentLoop @Inject constructor(
         }
     }
 
-    private suspend fun executePlanLoop(plan: Plan, context: Context, sessionId: String) {
+    private suspend fun executePlanLoop(plan: Plan, context: Context, sessionId: String, autoApproved: Boolean = false) {
         planManager.updatePlanStatus(PlanStatus.RUNNING)
         var currentPlanState = planManager.currentPlan.value ?: return
 
@@ -871,6 +889,27 @@ class AgentLoop @Inject constructor(
                                         currentPlanState.steps.none { it.stepId == step.stepId }
                                     }
                             planManager.startNewPlan(currentPlanState.copy(steps = mergedSteps), context)
+                            // Auto-approved plans: silently injected steps must not run
+                            // past the allowlist. Re-check the merged plan's pending
+                            // steps; if any is blocked, park the WHOLE remainder back
+                            // in the PlanProposed gate. YOLO skips like all other
+                            // checks; manually-approved plans keep today's behavior.
+                            if (autoApproved) {
+                                val liveConfig = settingsRepository.llmConfig.first()
+                                val liveMode = liveConfig.resolvedAutoMode()
+                                if (liveMode != AutoMode.YOLO) {
+                                    val mergedPlan = planManager.currentPlan.value
+                                    val pending = mergedPlan?.steps?.filter { it.status == StepStatus.PENDING }.orEmpty()
+                                    val blocked = AutoApprovalPolicy.blockedActions(
+                                        liveConfig.effectiveGrantedActions().keys, pending
+                                    )
+                                    if (blocked.isNotEmpty() && mergedPlan != null) {
+                                        proposedPlanSessionId = sessionId
+                                        _agentState.value = AgentState.PlanProposed(mergedPlan)
+                                        return
+                                    }
+                                }
+                            }
                         }
                     }
                     else -> {
@@ -1186,6 +1225,26 @@ class AgentLoop @Inject constructor(
             actionDispatcher.execute(actionName, newParams, context),
             newParams
         )
+    }
+
+    /**
+     * Auto-approved plans never show the approval modal, so leave a badged
+     * trace message in the chat instead - the audit trail the spec requires.
+     * Speech leads with "Running:" so a hands-free user knows no approval
+     * prompt is coming.
+     */
+    private suspend fun recordAutoApprovedTrace(plan: Plan, mode: AutoMode, sessionId: String) {
+        val badge = if (mode == AutoMode.YOLO) "YOLO" else "Auto-approved"
+        val stepLines = plan.steps.joinToString("\n") { "• ${it.description}" }
+        val traceMsg = ChatMessage(
+            id = UUID.randomUUID().toString(),
+            text = "Running: ${plan.goal} (${plan.steps.size} steps)\n$stepLines",
+            sender = ChatMessage.Sender.AGENT,
+            modelBadge = badge
+        )
+        conversationRepository.insertMessage(sessionId, traceMsg)
+        memoryManager.storeMessage(traceMsg, sessionId)
+        onSpeakCallback?.invoke("Running: ${plan.goal}")
     }
 
     private suspend fun speakAndSaveSummary(plan: Plan, isSuccess: Boolean, sessionId: String) {

--- a/app/src/main/java/com/opendroid/ai/core/agent/AgentLoop.kt
+++ b/app/src/main/java/com/opendroid/ai/core/agent/AgentLoop.kt
@@ -548,8 +548,11 @@ class AgentLoop @Inject constructor(
             }
 
             planManager.startNewPlan(plan, context)
-            val autoMode = config.resolvedAutoMode()
-            if (AutoApprovalPolicy.shouldAutoApprove(autoMode, config.effectiveGrantedActions().keys, plan)) {
+            // Re-read after LLM work: user may have flipped mode or revoked grants
+            // while planning was in flight; stale pre-LLM config must not auto-run.
+            val liveConfig = settingsRepository.llmConfig.first()
+            val autoMode = liveConfig.resolvedAutoMode()
+            if (AutoApprovalPolicy.shouldAutoApprove(autoMode, liveConfig.effectiveGrantedActions().keys, plan)) {
                 recordAutoApprovedTrace(plan, autoMode, sessionId)
                 executePlanLoop(plan, context, sessionId, autoApproved = true)
             } else {

--- a/app/src/main/java/com/opendroid/ai/core/agent/AgentLoop.kt
+++ b/app/src/main/java/com/opendroid/ai/core/agent/AgentLoop.kt
@@ -393,6 +393,7 @@ class AgentLoop @Inject constructor(
         try {
             val provider = llmProviderFactory.getActiveProvider()
             val relevantContext = memoryManager.getRelevantContext(userMsg.text)
+            val autoModeLabel = settingsRepository.llmConfig.first().resolvedAutoMode().name
 
             val systemPrompt = """
                 You are OpenDroid, a friendly and helpful Android AI assistant.
@@ -402,6 +403,8 @@ class AgentLoop @Inject constructor(
                 You can control this Android device: open apps, set alarms, toggle WiFi/Bluetooth/flashlight, send messages, make calls, and more. If someone asks you to do something, just do it or let them know you can help.
                 
                 Never dump raw error messages or technical details. If something goes wrong, say it simply and suggest what to do next.
+
+                Plan auto-approval mode is currently: $autoModeLabel (OFF = every plan needs manual approval, AUTO = allowlisted plans run automatically, YOLO = all plans run automatically). You cannot change this mode; the user changes it in Settings or via the chat mode chip.
                 
                 Context about user and device state:
                 $relevantContext

--- a/app/src/main/java/com/opendroid/ai/core/agent/AutoApprovalPolicy.kt
+++ b/app/src/main/java/com/opendroid/ai/core/agent/AutoApprovalPolicy.kt
@@ -18,9 +18,15 @@ object AutoApprovalPolicy {
         AutoMode.AUTO -> blockedActions(granted, plan.steps).isEmpty()
     }
 
-    /** Distinct actions (in step order) that keep this plan from auto-running. */
+    /**
+     * Distinct actions (in step order) that keep this plan from auto-running.
+     * Includes each step's non-blank [PlanStep.fallback] — AgentLoop executes
+     * fallbacks on primary failure, so they must pass the same allowlist gate.
+     */
     fun blockedActions(granted: Set<String>, steps: List<PlanStep>): List<String> =
-        steps.map { it.action }
+        steps.flatMap { step ->
+            listOfNotNull(step.action, step.fallback.takeIf { it.isNotBlank() })
+        }
             .distinct()
             .filter { it !in granted || ActionSchema.isNeverAutoApprove(it) }
 

--- a/app/src/main/java/com/opendroid/ai/core/agent/AutoApprovalPolicy.kt
+++ b/app/src/main/java/com/opendroid/ai/core/agent/AutoApprovalPolicy.kt
@@ -1,0 +1,30 @@
+package com.opendroid.ai.core.agent
+
+import com.opendroid.ai.data.models.AutoMode
+import com.opendroid.ai.data.models.Plan
+import com.opendroid.ai.data.models.PlanStep
+
+/**
+ * Pure decision logic for Auto mode (upstream issue 18 spec). Mixed plans are
+ * all-or-nothing: a plan auto-runs only when EVERY step's action is granted
+ * and none is neverAutoApprove; YOLO bypasses both checks. No mid-plan pause
+ * states — a blocked plan falls back to the normal PlanProposed gate whole.
+ */
+object AutoApprovalPolicy {
+
+    fun shouldAutoApprove(mode: AutoMode, granted: Set<String>, plan: Plan): Boolean = when (mode) {
+        AutoMode.OFF -> false
+        AutoMode.YOLO -> true
+        AutoMode.AUTO -> blockedActions(granted, plan.steps).isEmpty()
+    }
+
+    /** Distinct actions (in step order) that keep this plan from auto-running. */
+    fun blockedActions(granted: Set<String>, steps: List<PlanStep>): List<String> =
+        steps.map { it.action }
+            .distinct()
+            .filter { it !in granted || ActionSchema.isNeverAutoApprove(it) }
+
+    /** Only known, non-neverAutoApprove actions may ever be granted. */
+    fun isGrantable(actionName: String): Boolean =
+        ActionSchema.ALL_ACTIONS.any { it.name == actionName } && !ActionSchema.isNeverAutoApprove(actionName)
+}

--- a/app/src/main/java/com/opendroid/ai/core/service/OpenDroidService.kt
+++ b/app/src/main/java/com/opendroid/ai/core/service/OpenDroidService.kt
@@ -12,6 +12,8 @@ import com.opendroid.ai.core.agent.AgentLoop
 import com.opendroid.ai.core.agent.AgentState
 import com.opendroid.ai.core.voice.SpeechRecognitionEngine
 import com.opendroid.ai.core.voice.TextToSpeechEngine
+import com.opendroid.ai.core.voice.VoiceApprovalIntent
+import com.opendroid.ai.core.voice.VoiceApprovalParser
 import com.opendroid.ai.core.voice.WakeWordDetector
 import com.opendroid.ai.data.repository.SettingsRepository
 import dagger.hilt.android.AndroidEntryPoint
@@ -38,6 +40,7 @@ class OpenDroidService : Service() {
 
     private val serviceScope = CoroutineScope(Dispatchers.Main + SupervisorJob())
     private var showFloatingButton = false
+    @Volatile private var pendingApprovalListen = false
 
     companion object {
         const val ACTION_TRIGGER_RECORD = "com.opendroid.ai.action.TRIGGER_RECORD"
@@ -70,7 +73,15 @@ class OpenDroidService : Service() {
 
         // Set TTS completion listener to transition back to Idle
         textToSpeechEngine.onCompletionListener = {
-            agentLoop.setAgentState(AgentState.Idle)
+            // Only Speaking resets to Idle - speech that happens to play while a
+            // plan sits in PlanProposed must not knock the approval gate over.
+            if (agentLoop.agentState.value is AgentState.Speaking) {
+                agentLoop.setAgentState(AgentState.Idle)
+            }
+            if (pendingApprovalListen) {
+                pendingApprovalListen = false
+                startListeningForApproval()
+            }
         }
 
         // Start Foreground Notification
@@ -85,6 +96,25 @@ class OpenDroidService : Service() {
                     wakeWordDetector.stopListening()
                 } else {
                     startWakeWordDetection()
+                }
+            }
+        }
+
+        // Hands-free plan approval (upstream issue 18 spec, voice section):
+        // speak the prompt once per proposed plan; auto-listen for the reply
+        // only in wake-word mode, where the user is known to be voice-driven.
+        serviceScope.launch {
+            var promptedPlanId: String? = null
+            agentLoop.agentState.collectLatest { state ->
+                if (state is AgentState.PlanProposed && state.plan.planId != promptedPlanId) {
+                    promptedPlanId = state.plan.planId
+                    textToSpeechEngine.speak(
+                        "I've planned: ${state.plan.goal}, ${state.plan.estimatedSteps} steps. " +
+                        "Say approve to run, or cancel."
+                    )
+                    if (!showFloatingButton) {
+                        pendingApprovalListen = true
+                    }
                 }
             }
         }
@@ -128,6 +158,29 @@ class OpenDroidService : Service() {
                         startListeningForQuery()
                     }
                 }
+            }
+        )
+    }
+
+    /**
+     * One-shot reply capture after the spoken approval prompt. Unrecognized
+     * speech (or an error) is a deliberate no-op: the plan stays in
+     * PlanProposed with the visual modal still on screen. Never a grant path -
+     * nothing spoken may widen the allowlist.
+     */
+    private fun startListeningForApproval() {
+        wakeWordDetector.stopListening()
+        speechRecognitionEngine.startListening(
+            onResult = { utterance ->
+                when (VoiceApprovalParser.parse(utterance)) {
+                    VoiceApprovalIntent.APPROVE -> agentLoop.approveProposedPlan(this)
+                    VoiceApprovalIntent.REJECT -> agentLoop.rejectProposedPlan()
+                    VoiceApprovalIntent.NONE -> Unit
+                }
+                if (!showFloatingButton) startWakeWordDetection()
+            },
+            onError = { _ ->
+                if (!showFloatingButton) startWakeWordDetection()
             }
         )
     }

--- a/app/src/main/java/com/opendroid/ai/core/voice/VoiceApprovalParser.kt
+++ b/app/src/main/java/com/opendroid/ai/core/voice/VoiceApprovalParser.kt
@@ -1,0 +1,28 @@
+package com.opendroid.ai.core.voice
+
+enum class VoiceApprovalIntent { APPROVE, REJECT, NONE }
+
+/**
+ * Fuzzy intent match for the spoken plan-approval prompt ("Say approve to
+ * run, or cancel"). Reject wins over approve: a misheard approval runs a
+ * plan, a misheard rejection merely leaves it waiting in the modal.
+ * Deliberately NOT a grant mechanism — nothing spoken may widen the
+ * allowlist (upstream issue 18 spec, voice section).
+ */
+object VoiceApprovalParser {
+
+    private val rejectPattern = Regex(
+        """\b(cancel|stop|reject|no)\b|\b(don't|do not)\s+(run|do|execute)\b""",
+        RegexOption.IGNORE_CASE
+    )
+    private val approvePattern = Regex(
+        """\b(approve|yes|run|go ahead|do it|execute)\b""",
+        RegexOption.IGNORE_CASE
+    )
+
+    fun parse(utterance: String): VoiceApprovalIntent = when {
+        rejectPattern.containsMatchIn(utterance) -> VoiceApprovalIntent.REJECT
+        approvePattern.containsMatchIn(utterance) -> VoiceApprovalIntent.APPROVE
+        else -> VoiceApprovalIntent.NONE
+    }
+}

--- a/app/src/main/java/com/opendroid/ai/data/models/AutoMode.kt
+++ b/app/src/main/java/com/opendroid/ai/data/models/AutoMode.kt
@@ -1,0 +1,31 @@
+package com.opendroid.ai.data.models
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Plan auto-approval mode. AUTO approves a plan only when every step's action
+ * is in the granted allowlist and none is flagged neverAutoApprove; YOLO
+ * approves everything (in-action destructive confirmations still fire).
+ */
+@Serializable
+enum class AutoMode {
+    OFF, AUTO, YOLO;
+
+    companion object {
+        /**
+         * Allowlist seeded on first run: read-only or reversible on-device
+         * actions with no external side effects. Connectivity toggles are
+         * deliberately excluded — reversible, but can strand the device
+         * offline mid-plan.
+         */
+        val DEFAULT_GRANTS: Set<String> = setOf(
+            // INFORMATION
+            "WEB_SEARCH", "GET_WEATHER", "GET_NEWS", "CALCULATE", "TRANSLATE",
+            "DEFINE_WORD", "CONVERT_UNITS", "CURRENCY_CONVERT", "CHECK_STOCK",
+            "SUMMARIZE_URL", "FACT_CHECK",
+            // Reversible SYSTEM
+            "TOGGLE_FLASHLIGHT", "TOGGLE_DND", "SET_BRIGHTNESS", "SET_VOLUME",
+            "SET_RINGER_MODE", "TAKE_SCREENSHOT", "GET_SYSTEM_INFO"
+        )
+    }
+}

--- a/app/src/main/java/com/opendroid/ai/data/models/LLMConfig.kt
+++ b/app/src/main/java/com/opendroid/ai/data/models/LLMConfig.kt
@@ -12,6 +12,13 @@ data class LLMConfig(
     // Off by default: LLM-generated plans must be confirmed by the user before
     // executing device actions (calls, messages, settings changes).
     val autoConfirmPlans: Boolean = false,
+    // Auto mode (see docs: upstream issue 18 spec). null = never set; resolvedAutoMode()
+    // migrates the legacy autoConfirmPlans flag (true behaved like YOLO).
+    val autoMode: AutoMode? = null,
+    // Action name -> grant timestamp (epoch millis; 0L = seeded default).
+    // null = never seeded; effectiveGrantedActions() falls back to defaults.
+    // An explicit empty map means "user revoked everything" and stays empty.
+    val grantedActions: Map<String, Long>? = null,
     val latencyBenchmarks: Map<String, Long> = emptyMap(), // Provider -> latency Ms
     val elevenLabsApiKey: String = "",
     val elevenLabsVoiceId: String = "",
@@ -24,3 +31,8 @@ data class LLMConfig(
     val modelCache: Map<String, List<AIModel>> = emptyMap() // Provider -> cached AIModels list
 )
 
+fun LLMConfig.resolvedAutoMode(): AutoMode =
+    autoMode ?: if (autoConfirmPlans) AutoMode.YOLO else AutoMode.OFF
+
+fun LLMConfig.effectiveGrantedActions(): Map<String, Long> =
+    grantedActions ?: AutoMode.DEFAULT_GRANTS.associateWith { 0L }

--- a/app/src/main/java/com/opendroid/ai/ui/screens/ChatScreen.kt
+++ b/app/src/main/java/com/opendroid/ai/ui/screens/ChatScreen.kt
@@ -46,8 +46,12 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.core.content.ContextCompat
 import com.opendroid.ai.core.agent.AgentState
+import com.opendroid.ai.core.agent.AutoApprovalPolicy
 import com.opendroid.ai.core.voice.SpeechRecognitionEngine
+import com.opendroid.ai.data.models.AutoMode
 import com.opendroid.ai.data.models.ChatMessage
+import com.opendroid.ai.data.models.effectiveGrantedActions
+import com.opendroid.ai.data.models.resolvedAutoMode
 import com.opendroid.ai.data.repository.ChatSession
 import com.opendroid.ai.ui.components.ContactPickerCard
 import com.opendroid.ai.ui.theme.*
@@ -76,6 +80,7 @@ fun ChatScreen(
     // chat is currently displayed - drives the chat-picker's "still running" indicator.
     val runningSessionId by viewModel.runningSessionId.collectAsState()
     val sessions by viewModel.sessions.collectAsState()
+    val llmConfig by viewModel.llmConfig.collectAsState()
     val currentSessionId = sessions.firstOrNull { it.isCurrent }?.id
     val runningElsewhere = runningSessionId != null && runningSessionId != currentSessionId
 
@@ -197,6 +202,30 @@ fun ChatScreen(
                     }
                 },
                 actions = {
+                    val autoMode = llmConfig.resolvedAutoMode()
+                    val chipColor = when (autoMode) {
+                        AutoMode.OFF -> TextSecondary
+                        AutoMode.AUTO -> AccentNeonGreen
+                        AutoMode.YOLO -> AccentRed
+                    }
+                    OutlinedButton(
+                        onClick = { viewModel.cycleAutoMode() },
+                        border = BorderStroke(1.dp, chipColor.copy(alpha = 0.6f)),
+                        colors = ButtonDefaults.outlinedButtonColors(contentColor = chipColor),
+                        contentPadding = PaddingValues(horizontal = 10.dp, vertical = 0.dp),
+                        modifier = Modifier.height(28.dp)
+                    ) {
+                        Text(
+                            text = when (autoMode) {
+                                AutoMode.OFF -> "MANUAL"
+                                AutoMode.AUTO -> "AUTO"
+                                AutoMode.YOLO -> "YOLO"
+                            },
+                            fontSize = 10.sp,
+                            fontFamily = FontFamily.Monospace,
+                            fontWeight = FontWeight.Bold
+                        )
+                    }
                     IconButton(onClick = { viewModel.newChat() }) {
                         Icon(
                             imageVector = Icons.Default.Add,
@@ -354,10 +383,17 @@ fun ChatScreen(
                 // user could approve/reject the wrong chat's plan without realizing it.
                 if (visibleAgentState is AgentState.PlanProposed) {
                     val proposedPlan = (visibleAgentState as AgentState.PlanProposed).plan
+                    val blocked = if (llmConfig.resolvedAutoMode() == AutoMode.AUTO) {
+                        AutoApprovalPolicy.blockedActions(
+                            llmConfig.effectiveGrantedActions().keys, proposedPlan.steps
+                        )
+                    } else emptyList()
                     ProposedPlanPrompt(
                         goal = proposedPlan.goal,
                         stepsCount = proposedPlan.estimatedSteps,
-                        onApprove = { viewModel.approvePlan(context) },
+                        blockedActions = blocked,
+                        grantableActions = blocked.filter { AutoApprovalPolicy.isGrantable(it) }.toSet(),
+                        onApprove = { grants -> viewModel.approvePlan(context, grants) },
                         onReject = { viewModel.rejectPlan() }
                     )
                 }
@@ -804,9 +840,12 @@ fun ThinkingBubble() {
 fun ProposedPlanPrompt(
     goal: String,
     stepsCount: Int,
-    onApprove: () -> Unit,
+    blockedActions: List<String> = emptyList(),
+    grantableActions: Set<String> = emptySet(),
+    onApprove: (Set<String>) -> Unit,
     onReject: () -> Unit
 ) {
+    var checkedGrants by remember { mutableStateOf(setOf<String>()) }
     Card(
         modifier = Modifier
             .fillMaxWidth()
@@ -845,6 +884,41 @@ fun ProposedPlanPrompt(
                 fontSize = 12.sp,
                 color = TextSecondary
             )
+            if (blockedActions.isNotEmpty()) {
+                Spacer(modifier = Modifier.height(12.dp))
+                Text(
+                    text = "BLOCKED AUTO-RUN — these steps aren't in your allowlist:",
+                    fontSize = 11.sp,
+                    fontFamily = FontFamily.Monospace,
+                    color = AccentRed
+                )
+                Spacer(modifier = Modifier.height(4.dp))
+                blockedActions.forEach { action ->
+                    if (action in grantableActions) {
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            Checkbox(
+                                checked = action in checkedGrants,
+                                onCheckedChange = { checked ->
+                                    checkedGrants = if (checked) checkedGrants + action else checkedGrants - action
+                                },
+                                colors = CheckboxDefaults.colors(checkedColor = AccentNeonGreen)
+                            )
+                            Text(
+                                text = "Always allow $action",
+                                fontSize = 13.sp,
+                                color = TextPrimary
+                            )
+                        }
+                    } else {
+                        Text(
+                            text = "• $action (always asks)",
+                            fontSize = 13.sp,
+                            color = TextSecondary,
+                            modifier = Modifier.padding(start = 12.dp, top = 4.dp)
+                        )
+                    }
+                }
+            }
             Spacer(modifier = Modifier.height(16.dp))
             Row(
                 modifier = Modifier.fillMaxWidth(),
@@ -860,7 +934,7 @@ fun ProposedPlanPrompt(
                 }
                 Spacer(modifier = Modifier.width(12.dp))
                 Button(
-                    onClick = onApprove,
+                    onClick = { onApprove(checkedGrants) },
                     colors = ButtonDefaults.buttonColors(containerColor = AccentNeonGreen, contentColor = DarkBackground),
                     shape = RoundedCornerShape(8.dp)
                 ) {

--- a/app/src/main/java/com/opendroid/ai/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/opendroid/ai/ui/screens/SettingsScreen.kt
@@ -1,6 +1,7 @@
 package com.opendroid.ai.ui.screens
 
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -32,7 +33,10 @@ import androidx.compose.material.icons.filled.VisibilityOff
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
+import com.opendroid.ai.data.models.AutoMode
 import com.opendroid.ai.data.models.LLMConfig
+import com.opendroid.ai.data.models.effectiveGrantedActions
+import com.opendroid.ai.data.models.resolvedAutoMode
 import com.opendroid.ai.core.llm.OnDeviceModelRegistry
 import com.opendroid.ai.core.llm.OnDeviceBackend
 import com.google.mlkit.genai.prompt.*
@@ -1383,33 +1387,107 @@ fun SettingsScreen(
                         )
                         Spacer(modifier = Modifier.height(16.dp))
 
-                        Row(
-                            modifier = Modifier.fillMaxWidth(),
-                            horizontalArrangement = Arrangement.SpaceBetween,
-                            verticalAlignment = Alignment.CenterVertically
-                        ) {
-                            Column(modifier = Modifier.weight(1f)) {
-                                Text(
-                                    text = "Auto-Execute Plans",
-                                    fontSize = 15.sp,
-                                    fontWeight = FontWeight.SemiBold,
-                                    color = TextPrimary
-                                )
-                                Text(
-                                    text = "Run planned actions automatically without requiring manual approval.",
-                                    fontSize = 12.sp,
-                                    color = TextSecondary
-                                )
+                        var showYoloWarning by remember { mutableStateOf(false) }
+                        val autoMode = config.resolvedAutoMode()
+
+                        Text(
+                            text = "Auto Mode",
+                            fontSize = 15.sp,
+                            fontWeight = FontWeight.SemiBold,
+                            color = TextPrimary
+                        )
+                        Text(
+                            text = "Auto runs plans whose every step you've allowed. YOLO runs everything without asking.",
+                            fontSize = 12.sp,
+                            color = TextSecondary
+                        )
+                        Spacer(modifier = Modifier.height(12.dp))
+                        Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                            AutoMode.entries.forEach { mode ->
+                                val selected = autoMode == mode
+                                val accent = if (mode == AutoMode.YOLO) AccentRed else AccentNeonGreen
+                                OutlinedButton(
+                                    onClick = {
+                                        if (mode == AutoMode.YOLO && !selected) showYoloWarning = true
+                                        else viewModel.setAutoMode(mode)
+                                    },
+                                    colors = ButtonDefaults.outlinedButtonColors(
+                                        contentColor = if (selected) accent else TextSecondary
+                                    ),
+                                    border = BorderStroke(1.dp, if (selected) accent else BorderColor),
+                                    shape = RoundedCornerShape(8.dp),
+                                    modifier = Modifier.weight(1f)
+                                ) {
+                                    Text(
+                                        text = when (mode) {
+                                            AutoMode.OFF -> "Off"
+                                            AutoMode.AUTO -> "Auto"
+                                            AutoMode.YOLO -> "YOLO"
+                                        },
+                                        fontWeight = if (selected) FontWeight.Bold else FontWeight.Normal
+                                    )
+                                }
                             }
-                            Switch(
-                                checked = config.autoConfirmPlans,
-                                onCheckedChange = { viewModel.updateAutoConfirmPlans(it) },
-                                colors = SwitchDefaults.colors(
-                                    checkedThumbColor = AccentNeonGreen,
-                                    checkedTrackColor = AccentNeonGreen.copy(alpha = 0.5f)
-                                )
+                        }
+
+                        if (showYoloWarning) {
+                            AlertDialog(
+                                onDismissRequest = { showYoloWarning = false },
+                                containerColor = DarkSurface,
+                                title = { Text("Enable YOLO mode?", color = AccentRed, fontWeight = FontWeight.Bold) },
+                                text = {
+                                    Text(
+                                        "YOLO runs EVERY plan without asking — including actions that " +
+                                        "spend money (UPI payments, food and cab orders) and irreversible " +
+                                        "ones (installing apps, deleting files, restarting the device). " +
+                                        "Only per-action safety confirmations remain.",
+                                        color = TextPrimary
+                                    )
+                                },
+                                confirmButton = {
+                                    TextButton(onClick = {
+                                        showYoloWarning = false
+                                        viewModel.setAutoMode(AutoMode.YOLO)
+                                    }) { Text("I understand, enable", color = AccentRed) }
+                                },
+                                dismissButton = {
+                                    TextButton(onClick = { showYoloWarning = false }) {
+                                        Text("Cancel", color = TextSecondary)
+                                    }
+                                }
                             )
                         }
+
+                        Spacer(modifier = Modifier.height(16.dp))
+                        Text(
+                            text = "ALLOWED ACTIONS (${config.effectiveGrantedActions().size})",
+                            fontSize = 11.sp,
+                            fontFamily = FontFamily.Monospace,
+                            color = AccentCyan
+                        )
+                        Spacer(modifier = Modifier.height(4.dp))
+                        val dateFormat = remember { java.text.SimpleDateFormat("d MMM yyyy", java.util.Locale.getDefault()) }
+                        config.effectiveGrantedActions().entries
+                            .sortedBy { it.key }
+                            .forEach { (action, grantedAt) ->
+                                Row(
+                                    modifier = Modifier.fillMaxWidth().padding(vertical = 2.dp),
+                                    horizontalArrangement = Arrangement.SpaceBetween,
+                                    verticalAlignment = Alignment.CenterVertically
+                                ) {
+                                    Column(modifier = Modifier.weight(1f)) {
+                                        Text(text = action, fontSize = 13.sp, fontFamily = FontFamily.Monospace, color = TextPrimary)
+                                        Text(
+                                            text = if (grantedAt == 0L) "Default" else "Granted ${dateFormat.format(java.util.Date(grantedAt))}",
+                                            fontSize = 11.sp,
+                                            color = TextSecondary
+                                        )
+                                    }
+                                    TextButton(onClick = { viewModel.revokeGrant(action) }) {
+                                        Text("Revoke", color = AccentRed, fontSize = 12.sp)
+                                    }
+                                }
+                            }
 
                         Spacer(modifier = Modifier.height(16.dp))
                         Box(

--- a/app/src/main/java/com/opendroid/ai/ui/viewmodel/ChatViewModel.kt
+++ b/app/src/main/java/com/opendroid/ai/ui/viewmodel/ChatViewModel.kt
@@ -5,9 +5,13 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.opendroid.ai.core.agent.AgentLoop
 import com.opendroid.ai.core.agent.AgentState
+import com.opendroid.ai.data.models.AutoMode
 import com.opendroid.ai.data.models.ChatMessage
+import com.opendroid.ai.data.models.LLMConfig
+import com.opendroid.ai.data.models.resolvedAutoMode
 import com.opendroid.ai.data.repository.ChatSession
 import com.opendroid.ai.data.repository.ConversationRepository
+import com.opendroid.ai.data.repository.SettingsRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -20,8 +24,12 @@ import javax.inject.Inject
 @HiltViewModel
 class ChatViewModel @Inject constructor(
     private val agentLoop: AgentLoop,
-    private val conversationRepository: ConversationRepository
+    private val conversationRepository: ConversationRepository,
+    private val settingsRepository: SettingsRepository
 ) : ViewModel() {
+
+    val llmConfig: StateFlow<LLMConfig> = settingsRepository.llmConfig
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), LLMConfig())
 
     // Scoped to whichever session is current; re-collects automatically when the
     // user switches chats since the repository's flow is driven off the same
@@ -134,9 +142,25 @@ class ChatViewModel @Inject constructor(
         }
     }
 
-    fun approvePlan(context: Context) {
+    fun approvePlan(context: Context, grants: Set<String> = emptySet()) {
         pinTaskSessionSnapshot()
-        agentLoop.approveProposedPlan(context)
+        agentLoop.approveProposedPlan(context, grants)
+    }
+
+    /** Chip tap: Off <-> Auto only. YOLO is entered solely from Settings behind
+     *  its warning dialog and exits to OFF from here (tapping the red chip is
+     *  an explicit "get me out of YOLO", which is always safe). */
+    fun cycleAutoMode() {
+        viewModelScope.launch {
+            settingsRepository.updateConfig { current ->
+                val next = when (current.resolvedAutoMode()) {
+                    AutoMode.OFF -> AutoMode.AUTO
+                    AutoMode.AUTO -> AutoMode.OFF
+                    AutoMode.YOLO -> AutoMode.OFF
+                }
+                current.copy(autoMode = next, autoConfirmPlans = next == AutoMode.YOLO)
+            }
+        }
     }
 
     fun rejectPlan() {

--- a/app/src/main/java/com/opendroid/ai/ui/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/com/opendroid/ai/ui/viewmodel/SettingsViewModel.kt
@@ -2,7 +2,9 @@ package com.opendroid.ai.ui.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.opendroid.ai.data.models.AutoMode
 import com.opendroid.ai.data.models.LLMConfig
+import com.opendroid.ai.data.models.effectiveGrantedActions
 import com.opendroid.ai.data.repository.SettingsRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.StateFlow
@@ -412,11 +414,24 @@ class SettingsViewModel @Inject constructor(
         }
     }
 
-    fun updateAutoConfirmPlans(enabled: Boolean) {
-        _llmConfig.value = _llmConfig.value.copy(autoConfirmPlans = enabled)
+    fun setAutoMode(mode: AutoMode) {
+        _llmConfig.value = _llmConfig.value.copy(autoMode = mode, autoConfirmPlans = mode == AutoMode.YOLO)
         viewModelScope.launch {
             settingsRepository.updateConfig { current ->
-                current.copy(autoConfirmPlans = enabled)
+                current.copy(autoMode = mode, autoConfirmPlans = mode == AutoMode.YOLO)
+            }
+        }
+    }
+
+    /** Removes one grant. Writes the RESOLVED map minus the action, so the
+     *  first revoke also materializes the seeded defaults (a revoked default
+     *  must never come back on the next read). */
+    fun revokeGrant(action: String) {
+        val updated = _llmConfig.value.effectiveGrantedActions() - action
+        _llmConfig.value = _llmConfig.value.copy(grantedActions = updated)
+        viewModelScope.launch {
+            settingsRepository.updateConfig { current ->
+                current.copy(grantedActions = current.effectiveGrantedActions() - action)
             }
         }
     }

--- a/app/src/test/java/com/opendroid/ai/core/agent/AutoApprovalPolicyTest.kt
+++ b/app/src/test/java/com/opendroid/ai/core/agent/AutoApprovalPolicyTest.kt
@@ -1,0 +1,68 @@
+package com.opendroid.ai.core.agent
+
+import com.opendroid.ai.data.models.AutoMode
+import com.opendroid.ai.data.models.Plan
+import com.opendroid.ai.data.models.PlanStep
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AutoApprovalPolicyTest {
+
+    private fun step(id: String, action: String) = PlanStep(
+        stepId = id,
+        order = id.substring(1).toInt(),
+        description = "step $id",
+        action = action,
+        params = emptyMap()
+    )
+
+    private fun plan(vararg actions: String) = Plan(
+        planId = "p1",
+        goal = "test goal",
+        estimatedDuration = "1m",
+        estimatedSteps = actions.size,
+        steps = actions.mapIndexed { i, a -> step("s$i", a) }
+    )
+
+    private val granted = setOf("WEB_SEARCH", "GET_WEATHER", "SET_BRIGHTNESS")
+
+    @Test
+    fun `OFF never auto-approves`() {
+        assertFalse(AutoApprovalPolicy.shouldAutoApprove(AutoMode.OFF, granted, plan("WEB_SEARCH")))
+    }
+
+    @Test
+    fun `AUTO approves when every step is granted`() {
+        assertTrue(AutoApprovalPolicy.shouldAutoApprove(AutoMode.AUTO, granted, plan("WEB_SEARCH", "GET_WEATHER")))
+    }
+
+    @Test
+    fun `AUTO is all-or-nothing - one ungranted step blocks the whole plan`() {
+        assertFalse(AutoApprovalPolicy.shouldAutoApprove(AutoMode.AUTO, granted, plan("WEB_SEARCH", "SEND_SMS")))
+    }
+
+    @Test
+    fun `AUTO never approves a neverAutoApprove action even if somehow granted`() {
+        assertFalse(AutoApprovalPolicy.shouldAutoApprove(AutoMode.AUTO, granted + "PAY_UPI", plan("PAY_UPI")))
+    }
+
+    @Test
+    fun `YOLO approves everything including neverAutoApprove actions`() {
+        assertTrue(AutoApprovalPolicy.shouldAutoApprove(AutoMode.YOLO, emptySet(), plan("PAY_UPI", "DELETE_FILE")))
+    }
+
+    @Test
+    fun `blockedActions lists distinct ungranted or flagged actions in step order`() {
+        val steps = plan("WEB_SEARCH", "SEND_SMS", "PAY_UPI", "SEND_SMS").steps
+        assertEquals(listOf("SEND_SMS", "PAY_UPI"), AutoApprovalPolicy.blockedActions(granted, steps))
+    }
+
+    @Test
+    fun `grantable excludes neverAutoApprove and unknown actions`() {
+        assertTrue(AutoApprovalPolicy.isGrantable("SEND_SMS"))
+        assertFalse(AutoApprovalPolicy.isGrantable("PAY_UPI"))
+        assertFalse(AutoApprovalPolicy.isGrantable("NOT_A_REAL_ACTION"))
+    }
+}

--- a/app/src/test/java/com/opendroid/ai/core/agent/AutoApprovalPolicyTest.kt
+++ b/app/src/test/java/com/opendroid/ai/core/agent/AutoApprovalPolicyTest.kt
@@ -10,12 +10,13 @@ import org.junit.Test
 
 class AutoApprovalPolicyTest {
 
-    private fun step(id: String, action: String) = PlanStep(
+    private fun step(id: String, action: String, fallback: String = "") = PlanStep(
         stepId = id,
         order = id.substring(1).toInt(),
         description = "step $id",
         action = action,
-        params = emptyMap()
+        params = emptyMap(),
+        fallback = fallback
     )
 
     private fun plan(vararg actions: String) = Plan(
@@ -64,5 +65,37 @@ class AutoApprovalPolicyTest {
         assertTrue(AutoApprovalPolicy.isGrantable("SEND_SMS"))
         assertFalse(AutoApprovalPolicy.isGrantable("PAY_UPI"))
         assertFalse(AutoApprovalPolicy.isGrantable("NOT_A_REAL_ACTION"))
+    }
+
+    @Test
+    fun `AUTO blocks when primary is granted but fallback is not`() {
+        val steps = listOf(step("s0", "WEB_SEARCH", fallback = "SEND_SMS"))
+        val p = Plan("p1", "test", "1m", 1, steps)
+        assertFalse(AutoApprovalPolicy.shouldAutoApprove(AutoMode.AUTO, granted, p))
+        assertEquals(listOf("SEND_SMS"), AutoApprovalPolicy.blockedActions(granted, steps))
+    }
+
+    @Test
+    fun `AUTO blocks neverAutoApprove fallback even if somehow granted`() {
+        val steps = listOf(step("s0", "WEB_SEARCH", fallback = "PAY_UPI"))
+        assertFalse(
+            AutoApprovalPolicy.shouldAutoApprove(AutoMode.AUTO, granted + "PAY_UPI", Plan("p1", "test", "1m", 1, steps))
+        )
+    }
+
+    @Test
+    fun `AUTO approves when primary and fallback are both granted`() {
+        val steps = listOf(step("s0", "WEB_SEARCH", fallback = "GET_WEATHER"))
+        assertTrue(
+            AutoApprovalPolicy.shouldAutoApprove(AutoMode.AUTO, granted, Plan("p1", "test", "1m", 1, steps))
+        )
+    }
+
+    @Test
+    fun `blank fallback is ignored`() {
+        val steps = listOf(step("s0", "WEB_SEARCH", fallback = "   "))
+        assertTrue(
+            AutoApprovalPolicy.shouldAutoApprove(AutoMode.AUTO, granted, Plan("p1", "test", "1m", 1, steps))
+        )
     }
 }

--- a/app/src/test/java/com/opendroid/ai/core/agent/NeverAutoApproveTest.kt
+++ b/app/src/test/java/com/opendroid/ai/core/agent/NeverAutoApproveTest.kt
@@ -1,0 +1,41 @@
+package com.opendroid.ai.core.agent
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * neverAutoApprove flag: actions that move money or have irreversible
+ * consequences must always hit the approval modal in Auto mode.
+ */
+class NeverAutoApproveTest {
+
+    @Test
+    fun `exactly the spec's ten actions are flagged`() {
+        val flagged = ActionSchema.ALL_ACTIONS.filter { it.neverAutoApprove }.map { it.name }.toSet()
+        assertEquals(
+            setOf(
+                // Money
+                "PAY_UPI", "ORDER_FOOD", "ORDER_GROCERY", "BOOK_UBER", "BOOK_OLA",
+                // Irreversible / destructive
+                "INSTALL_APP", "RESTART_DEVICE", "DELETE_FILE", "CLEAR_BROWSER_DATA", "LOCK_DOOR"
+            ),
+            flagged
+        )
+    }
+
+    @Test
+    fun `communication sends stay grantable`() {
+        assertFalse(ActionSchema.isNeverAutoApprove("SEND_SMS"))
+        assertFalse(ActionSchema.isNeverAutoApprove("SEND_EMAIL"))
+        assertFalse(ActionSchema.isNeverAutoApprove("SEND_WHATSAPP"))
+    }
+
+    @Test
+    fun `lookup helper matches the flag and tolerates unknown actions`() {
+        assertTrue(ActionSchema.isNeverAutoApprove("PAY_UPI"))
+        assertFalse(ActionSchema.isNeverAutoApprove("WEB_SEARCH"))
+        assertFalse(ActionSchema.isNeverAutoApprove("NOT_A_REAL_ACTION"))
+    }
+}

--- a/app/src/test/java/com/opendroid/ai/core/voice/VoiceApprovalParserTest.kt
+++ b/app/src/test/java/com/opendroid/ai/core/voice/VoiceApprovalParserTest.kt
@@ -1,0 +1,40 @@
+package com.opendroid.ai.core.voice
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class VoiceApprovalParserTest {
+
+    @Test
+    fun `approve terms`() {
+        for (u in listOf("approve", "Approve it", "yes", "yes please", "run", "run it", "go ahead", "okay do it")) {
+            assertEquals(u, VoiceApprovalIntent.APPROVE, VoiceApprovalParser.parse(u))
+        }
+    }
+
+    @Test
+    fun `reject terms`() {
+        for (u in listOf("cancel", "no", "No thanks", "stop", "reject", "don't run that", "do not run it")) {
+            assertEquals(u, VoiceApprovalIntent.REJECT, VoiceApprovalParser.parse(u))
+        }
+    }
+
+    @Test
+    fun `reject wins over approve in mixed utterances`() {
+        assertEquals(VoiceApprovalIntent.REJECT, VoiceApprovalParser.parse("no, don't run it"))
+        assertEquals(VoiceApprovalIntent.REJECT, VoiceApprovalParser.parse("yes actually cancel that"))
+    }
+
+    @Test
+    fun `word boundaries - substrings do not match`() {
+        // "know" contains "no", "canceled culture" is contrived but "runway" contains "run"
+        assertEquals(VoiceApprovalIntent.NONE, VoiceApprovalParser.parse("I don't know"))
+        assertEquals(VoiceApprovalIntent.NONE, VoiceApprovalParser.parse("show me the runway"))
+    }
+
+    @Test
+    fun `anything else is a no-op`() {
+        assertEquals(VoiceApprovalIntent.NONE, VoiceApprovalParser.parse("what's the weather"))
+        assertEquals(VoiceApprovalIntent.NONE, VoiceApprovalParser.parse(""))
+    }
+}

--- a/app/src/test/java/com/opendroid/ai/data/models/AutoModeConfigTest.kt
+++ b/app/src/test/java/com/opendroid/ai/data/models/AutoModeConfigTest.kt
@@ -1,0 +1,68 @@
+package com.opendroid.ai.data.models
+
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Auto mode persistence on [LLMConfig]: legacy-flag migration and
+ * default-allowlist seeding. Pure logic, no Android dependencies.
+ */
+class AutoModeConfigTest {
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    @Test
+    fun `unset mode with legacy autoConfirmPlans false resolves to OFF`() {
+        assertEquals(AutoMode.OFF, LLMConfig().resolvedAutoMode())
+    }
+
+    @Test
+    fun `unset mode with legacy autoConfirmPlans true resolves to YOLO`() {
+        assertEquals(AutoMode.YOLO, LLMConfig(autoConfirmPlans = true).resolvedAutoMode())
+    }
+
+    @Test
+    fun `explicit mode wins over legacy flag`() {
+        assertEquals(AutoMode.OFF, LLMConfig(autoConfirmPlans = true, autoMode = AutoMode.OFF).resolvedAutoMode())
+        assertEquals(AutoMode.AUTO, LLMConfig(autoMode = AutoMode.AUTO).resolvedAutoMode())
+    }
+
+    @Test
+    fun `unseeded grants resolve to the default allowlist with timestamp zero`() {
+        val grants = LLMConfig().effectiveGrantedActions()
+        assertEquals(AutoMode.DEFAULT_GRANTS, grants.keys)
+        assertTrue(grants.values.all { it == 0L })
+    }
+
+    @Test
+    fun `seeded grants are returned verbatim - even when empty`() {
+        // User revoked everything: empty map must NOT fall back to defaults.
+        assertEquals(emptyMap<String, Long>(), LLMConfig(grantedActions = emptyMap()).effectiveGrantedActions())
+        val custom = mapOf("WEB_SEARCH" to 123L)
+        assertEquals(custom, LLMConfig(grantedActions = custom).effectiveGrantedActions())
+    }
+
+    @Test
+    fun `default allowlist is exactly the spec's 18 actions`() {
+        assertEquals(
+            setOf(
+                "WEB_SEARCH", "GET_WEATHER", "GET_NEWS", "CALCULATE", "TRANSLATE",
+                "DEFINE_WORD", "CONVERT_UNITS", "CURRENCY_CONVERT", "CHECK_STOCK",
+                "SUMMARIZE_URL", "FACT_CHECK",
+                "TOGGLE_FLASHLIGHT", "TOGGLE_DND", "SET_BRIGHTNESS", "SET_VOLUME",
+                "SET_RINGER_MODE", "TAKE_SCREENSHOT", "GET_SYSTEM_INFO"
+            ),
+            AutoMode.DEFAULT_GRANTS
+        )
+    }
+
+    @Test
+    fun `old persisted JSON without new fields still decodes`() {
+        val config = json.decodeFromString<LLMConfig>("""{"activeProvider":"Google Gemini","autoConfirmPlans":true}""")
+        assertEquals(AutoMode.YOLO, config.resolvedAutoMode())
+        assertFalse(config.effectiveGrantedActions().isEmpty())
+    }
+}


### PR DESCRIPTION
## Summary

Implements #18 ([spec](https://github.com/yashab-cyber/opendroid/issues/18#issuecomment-5105417585)): Off / Auto / YOLO plan auto-approval with a per-action allowlist that grows only from explicit grants.

- Core: `AutoMode` + persisted grants on `LLMConfig`, `neverAutoApprove` on risky actions, `AutoApprovalPolicy`, `AgentLoop` gate / audit trace / replan re-check (including step fallbacks), `VoiceApprovalParser`
- UI: chat mode chip (Off ↔ Auto; YOLO exits to Off), approval modal with blocked steps and “Always allow” checkboxes
- Settings: mode selector, YOLO warning dialog, revocable allowed-actions list (replaces legacy auto-execute switch)
- Voice: spoken approve/cancel for proposed plans in wake-word mode; current mode exposed to simple chat queries

## Test plan

- [x] `./gradlew :app:testDebugUnitTest` (JDK 21)
- [x] Settings → Auto mode: Off / Auto / YOLO; YOLO shows warning; revoke a default grant and confirm it stays revoked
- [x] Auto mode + allowlisted-only plan runs without modal; mixed plan (or ungranted fallback) shows modal
- [ ] Chat chip cycles MANUAL ↔ AUTO; YOLO chip tap returns to MANUAL
- [ ] Change mode / revoke grants while a plan is generating — completed plan respects the live setting
- [ ] Wake-word flow: proposed plan speaks prompt; “approve” / “cancel” works; modal still available in parallel
