### PR TITLE
Website: light/dark mode + nav accessibility fix + real bug fixes

### DIFF
--- a/website/about.html
+++ b/website/about.html
@@ -25,17 +25,8 @@
       <img src="assets/bot.png" alt="OpenDroid">
       <span>OpenDroid</span>
     </a>
-    <button class="nav-hamburger" id="nav-hamburger" aria-label="Toggle menu">
-      <span></span><span></span><span></span>
-    </button>
+    <div class="nav-right">
     <ul class="nav-links" id="nav-links">
-      <li class="theme-toggle-item">
-        <button class="theme-toggle" id="theme-toggle" type="button" aria-label="Activer le mode clair" aria-pressed="false">
-          <svg class="icon-sun" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"></circle><line x1="12" y1="1" x2="12" y2="3"></line><line x1="12" y1="21" x2="12" y2="23"></line><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line><line x1="1" y1="12" x2="3" y2="12"></line><line x1="21" y1="12" x2="23" y2="12"></line><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line></svg>
-          <svg class="icon-moon" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path></svg>
-        </button>
-      </li>
-
       <li class="nav-dropdown">
         <a href="features.html">Products</a>
         <ul class="dropdown-menu">
@@ -70,6 +61,16 @@
         <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align: middle; margin-left: 4px;"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path><polyline points="7 10 12 15 17 10"></polyline><line x1="12" y1="15" x2="12" y2="3"></line></svg>
       </a></li>
     </ul>
+    <div class="nav-controls">
+      <button class="theme-toggle" id="theme-toggle" type="button" aria-label="Enable light mode" aria-pressed="false">
+        <svg class="icon-sun" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"></circle><line x1="12" y1="1" x2="12" y2="3"></line><line x1="12" y1="21" x2="12" y2="23"></line><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line><line x1="1" y1="12" x2="3" y2="12"></line><line x1="21" y1="12" x2="23" y2="12"></line><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line></svg>
+        <svg class="icon-moon" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path></svg>
+        <span class="theme-toggle-text-wrap"><span class="tt-dark">Dark</span><span class="tt-light">Light</span></span>
+      </button>
+      <button class="nav-hamburger" id="nav-hamburger" aria-label="Toggle menu">
+        <span></span><span></span><span></span>
+      </button>
+    </div>
   </div>
 </nav>
 

--- a/website/about.html
+++ b/website/about.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <script>document.documentElement.setAttribute('data-theme', localStorage.getItem('opendroid-theme') || 'dark');</script>
+
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>About — OpenDroid</title>
@@ -27,6 +29,13 @@
       <span></span><span></span><span></span>
     </button>
     <ul class="nav-links" id="nav-links">
+      <li class="theme-toggle-item">
+        <button class="theme-toggle" id="theme-toggle" type="button" aria-label="Activer le mode clair" aria-pressed="false">
+          <svg class="icon-sun" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"></circle><line x1="12" y1="1" x2="12" y2="3"></line><line x1="12" y1="21" x2="12" y2="23"></line><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line><line x1="1" y1="12" x2="3" y2="12"></line><line x1="21" y1="12" x2="23" y2="12"></line><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line></svg>
+          <svg class="icon-moon" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path></svg>
+        </button>
+      </li>
+
       <li class="nav-dropdown">
         <a href="features.html">Products</a>
         <ul class="dropdown-menu">

--- a/website/contributor.html
+++ b/website/contributor.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <script>document.documentElement.setAttribute('data-theme', localStorage.getItem('opendroid-theme') || 'dark');</script>
+
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Contributors &amp; Testers — OpenDroid</title>
@@ -263,6 +265,13 @@
       <span></span><span></span><span></span>
     </button>
     <ul class="nav-links" id="nav-links">
+      <li class="theme-toggle-item">
+        <button class="theme-toggle" id="theme-toggle" type="button" aria-label="Activer le mode clair" aria-pressed="false">
+          <svg class="icon-sun" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"></circle><line x1="12" y1="1" x2="12" y2="3"></line><line x1="12" y1="21" x2="12" y2="23"></line><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line><line x1="1" y1="12" x2="3" y2="12"></line><line x1="21" y1="12" x2="23" y2="12"></line><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line></svg>
+          <svg class="icon-moon" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path></svg>
+        </button>
+      </li>
+
       <li class="nav-dropdown">
         <a href="features.html">Products</a>
         <ul class="dropdown-menu">

--- a/website/contributor.html
+++ b/website/contributor.html
@@ -16,241 +16,6 @@
   <link rel="canonical" href="https://yashab-cyber.github.io/opendroid/contributor.html">
   <link rel="icon" type="image/png" href="assets/bot.png">
   <link rel="stylesheet" href="css/style.css">
-  <style>
-    /* Profile styling specific to contributor page */
-    .profile-section {
-      padding: 60px 0;
-    }
-    .profile-grid {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
-      gap: 30px;
-      margin-top: 30px;
-    }
-    @media (max-width: 992px) {
-      .profile-grid {
-        grid-template-columns: repeat(auto-fit, minmax(290px, 1fr));
-      }
-    }
-    .profile-card {
-      display: flex;
-      flex-direction: column;
-      height: 100%;
-      padding: 32px;
-      background: var(--surface);
-      border: 1px solid var(--surface-border);
-      border-radius: var(--radius-xl);
-      transition: all var(--transition);
-      position: relative;
-      overflow: hidden;
-      box-shadow: var(--shadow-sm);
-    }
-    .profile-card::before {
-      content: '';
-      position: absolute;
-      top: 0; left: 0; right: 0; height: 6px;
-      background: linear-gradient(90deg, var(--accent) 0%, #3b82f6 100%);
-      opacity: 0.8;
-    }
-    .profile-card:hover {
-      transform: translateY(-6px);
-      box-shadow: var(--shadow-lg);
-      border-color: rgba(16, 185, 129, 0.3);
-    }
-    .profile-header {
-      display: flex;
-      align-items: center;
-      gap: 18px;
-      margin-bottom: 20px;
-    }
-    .avatar-wrapper {
-      position: relative;
-      width: 76px;
-      height: 76px;
-      border-radius: 50%;
-      padding: 3px;
-      background: linear-gradient(135deg, var(--accent) 0%, #3b82f6 100%);
-      flex-shrink: 0;
-    }
-    .avatar-img {
-      width: 100%;
-      height: 100%;
-      object-fit: cover;
-      border-radius: 50%;
-      border: 3px solid var(--surface);
-      transition: transform var(--transition);
-    }
-    .profile-card:hover .avatar-img {
-      transform: scale(1.04);
-    }
-    .status-badge {
-      position: absolute;
-      bottom: -2px;
-      right: -2px;
-      background: var(--accent-dark);
-      color: #fff;
-      font-size: 0.65rem;
-      font-weight: 700;
-      padding: 3px 8px;
-      border-radius: 100px;
-      border: 2px solid var(--surface);
-      box-shadow: var(--shadow-sm);
-    }
-    .profile-titles h3 {
-      font-size: 1.2rem;
-      margin-bottom: 2px;
-      font-family: var(--font-heading);
-      color: var(--text-primary);
-    }
-    .profile-username {
-      font-size: 0.85rem;
-      color: var(--accent-dark);
-      font-weight: 600;
-      transition: color var(--transition);
-    }
-    .profile-username:hover {
-      color: var(--accent);
-    }
-    .profile-body {
-      flex-grow: 1;
-    }
-    .profile-badges {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 6px;
-      margin-bottom: 16px;
-    }
-    .role-badge {
-      font-size: 0.72rem;
-      font-weight: 600;
-      padding: 4px 10px;
-      border-radius: 100px;
-      text-transform: uppercase;
-      letter-spacing: 0.02em;
-    }
-    .role-badge.contributor-badge {
-      background: var(--accent-light);
-      color: var(--accent-dark);
-    }
-    .role-badge.tester-badge {
-      background: #dbeafe;
-      color: #1e40af;
-    }
-    .role-badge.maintainer-badge {
-      background: #fef3c7;
-      color: #92400e;
-    }
-    .profile-bio {
-      font-size: 0.9rem;
-      color: var(--text-body);
-      line-height: 1.6;
-      margin-bottom: 20px;
-    }
-    .profile-achievements {
-      margin-bottom: 20px;
-      border-top: 1px solid var(--surface-border);
-      padding-top: 16px;
-    }
-    .ach-title {
-      font-size: 0.75rem;
-      text-transform: uppercase;
-      letter-spacing: 0.05em;
-      color: var(--text-muted);
-      margin-bottom: 10px;
-      font-weight: 600;
-    }
-    .ach-list {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 6px;
-    }
-    .ach-badge {
-      display: inline-flex;
-      align-items: center;
-      gap: 6px;
-      background: var(--bg-secondary);
-      border: 1px solid var(--surface-border);
-      padding: 4px 8px;
-      border-radius: 6px;
-      font-size: 0.72rem;
-      font-weight: 500;
-      color: var(--text-body);
-      transition: all var(--transition);
-    }
-    .ach-badge:hover {
-      background: var(--bg-tertiary);
-      border-color: rgba(16, 185, 129, 0.2);
-    }
-    .ach-badge img {
-      width: 14px;
-      height: 14px;
-      object-fit: contain;
-    }
-    .profile-stats {
-      display: flex;
-      gap: 20px;
-      margin-bottom: 24px;
-      border-top: 1px solid var(--surface-border);
-      padding-top: 16px;
-    }
-    .stat-item {
-      display: flex;
-      flex-direction: column;
-    }
-    .stat-num {
-      font-size: 1.1rem;
-      font-weight: 700;
-      color: var(--text-primary);
-    }
-    .stat-label {
-      font-size: 0.72rem;
-      color: var(--text-muted);
-    }
-    .profile-footer {
-      border-top: 1px solid var(--surface-border);
-      padding-top: 20px;
-      margin-top: auto;
-      display: flex;
-      gap: 10px;
-    }
-    .btn-sm {
-      padding: 8px 18px;
-      font-size: 0.8rem;
-    }
-    
-    /* Call to Action Grid Card */
-    .join-card {
-      border: 2px dashed var(--surface-border);
-      background: transparent;
-      justify-content: center;
-      align-items: center;
-      text-align: center;
-      min-height: 300px;
-    }
-    .join-card::before {
-      display: none;
-    }
-    .join-card:hover {
-      border-color: var(--accent);
-      background: rgba(16, 185, 129, 0.02);
-      transform: translateY(-4px);
-    }
-    .join-icon {
-      font-size: 2.2rem;
-      margin-bottom: 12px;
-      display: block;
-    }
-    .join-card h3 {
-      font-size: 1.15rem;
-      margin-bottom: 8px;
-    }
-    .join-card p {
-      font-size: 0.88rem;
-      color: var(--text-muted);
-      max-width: 250px;
-      margin: 0 auto 20px;
-    }
-  </style>
 </head>
 <body>
 
@@ -261,17 +26,8 @@
       <img src="assets/bot.png" alt="OpenDroid">
       <span>OpenDroid</span>
     </a>
-    <button class="nav-hamburger" id="nav-hamburger" aria-label="Toggle menu">
-      <span></span><span></span><span></span>
-    </button>
+    <div class="nav-right">
     <ul class="nav-links" id="nav-links">
-      <li class="theme-toggle-item">
-        <button class="theme-toggle" id="theme-toggle" type="button" aria-label="Activer le mode clair" aria-pressed="false">
-          <svg class="icon-sun" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"></circle><line x1="12" y1="1" x2="12" y2="3"></line><line x1="12" y1="21" x2="12" y2="23"></line><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line><line x1="1" y1="12" x2="3" y2="12"></line><line x1="21" y1="12" x2="23" y2="12"></line><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line></svg>
-          <svg class="icon-moon" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path></svg>
-        </button>
-      </li>
-
       <li class="nav-dropdown">
         <a href="features.html">Products</a>
         <ul class="dropdown-menu">
@@ -306,6 +62,16 @@
         <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align: middle; margin-left: 4px;"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path><polyline points="7 10 12 15 17 10"></polyline><line x1="12" y1="15" x2="12" y2="3"></line></svg>
       </a></li>
     </ul>
+    <div class="nav-controls">
+      <button class="theme-toggle" id="theme-toggle" type="button" aria-label="Enable light mode" aria-pressed="false">
+        <svg class="icon-sun" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"></circle><line x1="12" y1="1" x2="12" y2="3"></line><line x1="12" y1="21" x2="12" y2="23"></line><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line><line x1="1" y1="12" x2="3" y2="12"></line><line x1="21" y1="12" x2="23" y2="12"></line><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line></svg>
+        <svg class="icon-moon" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path></svg>
+        <span class="theme-toggle-text-wrap"><span class="tt-dark">Dark</span><span class="tt-light">Light</span></span>
+      </button>
+      <button class="nav-hamburger" id="nav-hamburger" aria-label="Toggle menu">
+        <span></span><span></span><span></span>
+      </button>
+    </div>
   </div>
 </nav>
 

--- a/website/css/style.css
+++ b/website/css/style.css
@@ -1,80 +1,91 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Outfit:wght@400;500;600;700;800&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600;700&display=swap');
 
+/* ============================================================
+   OpenDroid — design tokens
+   Two deliberate greens (a quiet forest for links/text-safe use,
+   a brighter moss for dark-mode legibility) plus the historic
+   Android "bugdroid" yellow-green kept strictly decorative
+   (insufficient contrast for text on either surface).
+   Ink/paper bases carry a faint green whisper rather than
+   neutral zinc grey, so dark and light read as one family.
+   ============================================================ */
 :root {
-  --bg-primary: #09090b; /* Zinc 950 */
-  --bg-secondary: #0f0f11;
-  --bg-tertiary: #18181b; /* Zinc 900 */
-  --surface: #18181b;
-  --surface-hover: #27272a; /* Zinc 800 */
-  --surface-border: rgba(255, 255, 255, 0.08);
-  --accent: #10b981; /* Desaturated emerald green */
-  --accent-light: rgba(16, 185, 129, 0.1);
-  --accent-dark: #059669;
-  --text-primary: #f4f4f5; /* Zinc 100 */
-  --text-body: #a1a1aa; /* Zinc 400 */
-  --text-muted: #71717a; /* Zinc 500 */
-  --shadow-sm: 0 1px 2px rgba(0,0,0,0.5);
-  --shadow-md: 0 4px 12px rgba(0,0,0,0.6);
-  --shadow-lg: 0 12px 40px rgba(0,0,0,0.8);
-  --radius-sm: 8px;
-  --radius-md: 12px;
-  --radius-lg: 16px;
-  --radius-xl: 24px;
-  --font-body: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
-  --font-heading: 'Outfit', 'Inter', sans-serif;
+  --bg-primary: #0B0F0D;
+  --bg-secondary: #10150F;
+  --bg-tertiary: #161C16;
+  --surface: #141914;
+  --surface-hover: #1C231B;
+  --surface-border: rgba(180, 200, 165, 0.12);
+  --accent: #4FBE72;
+  --accent-light: rgba(79, 190, 114, 0.12);
+  --accent-dark: #3FA362;
+  --bugdroid: #A4C639;
+  --text-primary: #EDEFE8;
+  --text-body: #A6AFA0;
+  --text-muted: #8B968C;
+  --shadow-sm: 0 1px 2px rgba(0,0,0,0.45);
+  --shadow-md: 0 6px 20px rgba(0,0,0,0.5);
+  --shadow-lg: 0 16px 44px rgba(0,0,0,0.6);
+  --radius-sm: 6px;
+  --radius-md: 10px;
+  --radius-lg: 14px;
+  --radius-xl: 20px;
+  --font-body: 'IBM Plex Sans', -apple-system, BlinkMacSystemFont, sans-serif;
+  --font-display: 'IBM Plex Mono', 'SFMono-Regular', Consolas, monospace;
   --nav-height: 64px;
   --max-width: 1140px;
-  --transition: 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+  --transition: 0.2s cubic-bezier(0.4, 0, 0.2, 1);
 
-  /* Theme-dependent surfaces (dark = default) */
-  --nav-bg: rgba(9, 9, 11, 0.8);
-  --nav-bg-mobile: rgba(9, 9, 11, 0.95);
-  --glass-bg: rgba(24, 24, 27, 0.7);
-  --hover-border: rgba(255, 255, 255, 0.15);
-  --node-fill: #18181b;
-  --node-fill-hover: #27272a;
-  --danger-bg: rgba(239, 68, 68, 0.12);
-  --danger-text: #f87171;
+  --nav-bg: rgba(11, 15, 13, 0.82);
+  --nav-bg-mobile: var(--bg-primary);
+  --glass-bg: rgba(20, 25, 20, 0.75);
+  --hover-border: rgba(180, 200, 165, 0.28);
+  --node-fill: #141914;
+  --node-fill-hover: #1C231B;
+  --danger-bg: rgba(226, 87, 74, 0.14);
+  --danger-text: #E8867A;
 }
 
 /* ── Light theme ── */
 html[data-theme="light"] {
-  --bg-primary: #ffffff;
-  --bg-secondary: #f6f7f8;
-  --bg-tertiary: #eef0f2;
-  --surface: #ffffff;
-  --surface-hover: #eef0f2;
-  --surface-border: rgba(0, 0, 0, 0.09);
-  --accent: #059669;
-  --accent-light: rgba(5, 150, 105, 0.1);
-  --accent-dark: #047857;
-  --text-primary: #18181b;
-  --text-body: #52525b;
-  --text-muted: #71717a;
-  --shadow-sm: 0 1px 2px rgba(0,0,0,0.06);
-  --shadow-md: 0 4px 12px rgba(0,0,0,0.08);
-  --shadow-lg: 0 12px 40px rgba(0,0,0,0.12);
+  --bg-primary: #FAFAF6;
+  --bg-secondary: #F1F1EA;
+  --bg-tertiary: #E9E9E0;
+  --surface: #FFFFFF;
+  --surface-hover: #F1F1EA;
+  --surface-border: rgba(30, 40, 20, 0.10);
+  --accent: #2E7D4F;
+  --accent-light: rgba(46, 125, 79, 0.10);
+  --accent-dark: #24623E;
+  --bugdroid: #7A9426;
+  --text-primary: #171B14;
+  --text-body: #4E5A47;
+  --text-muted: #5A6553;
+  --shadow-sm: 0 1px 2px rgba(20,30,15,0.06);
+  --shadow-md: 0 6px 20px rgba(20,30,15,0.08);
+  --shadow-lg: 0 16px 44px rgba(20,30,15,0.12);
 
-  --nav-bg: rgba(255, 255, 255, 0.85);
-  --nav-bg-mobile: rgba(255, 255, 255, 0.97);
-  --glass-bg: rgba(255, 255, 255, 0.7);
-  --hover-border: rgba(0, 0, 0, 0.15);
-  --node-fill: #f6f7f8;
-  --node-fill-hover: #eef0f2;
-  --danger-bg: #fee2e2;
-  --danger-text: #dc2626;
+  --nav-bg: rgba(250, 250, 246, 0.86);
+  --nav-bg-mobile: var(--bg-primary);
+  --glass-bg: rgba(255, 255, 255, 0.75);
+  --hover-border: rgba(30, 40, 20, 0.22);
+  --node-fill: #F1F1EA;
+  --node-fill-hover: #E9E9E0;
+  --danger-bg: #FBE4E0;
+  --danger-text: #B23B2E;
 }
 
 /* Smooth transition when switching themes */
-body, .navbar, .nav-links, .glass-card, .btn-secondary, .faq-item,
-.arch-svg .node-rect, .badge-unsupported {
+body, .navbar, .nav-links, .glass-card, .btn, .btn-secondary, .faq-item,
+.theme-toggle, .role-badge, .profile-card, .ach-badge,
+.arch-svg .node-rect, .badge-unsupported, .badge-supported {
   transition: background-color var(--transition), border-color var(--transition), color var(--transition);
 }
 
 /* ── Keyboard Focus Styles ── */
 *:focus-visible {
   outline: 2px solid var(--accent);
-  outline-offset: 4px;
+  outline-offset: 3px;
 }
 
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -89,21 +100,41 @@ body {
   min-height: 100vh;
 }
 
-h1, h2, h3, h4, h5, h6 {
-  font-family: var(--font-heading);
+/* Display headings (the big structural moments) set in mono —
+   card/component-level headings stay in the body face so small
+   sizes keep their refinement instead of feeling cramped. */
+h1, h2 {
+  font-family: var(--font-display);
   color: var(--text-primary);
-  line-height: 1.25;
-  font-weight: 700;
+  line-height: 1.2;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+h3, h4, h5, h6 {
+  font-family: var(--font-body);
+  color: var(--text-primary);
+  line-height: 1.3;
+  font-weight: 600;
 }
 h1 { font-size: clamp(2rem, 4.5vw, 3rem); }
-h2 { font-size: clamp(1.5rem, 3vw, 2.2rem); }
+h2 { font-size: clamp(1.4rem, 3vw, 2.1rem); }
 h3 { font-size: clamp(1.1rem, 2vw, 1.4rem); }
-h4 { font-size: 1.1rem; }
+h4 { font-size: 1.05rem; }
 p { margin-bottom: 1rem; }
 
-a { color: var(--accent-dark); text-decoration: none; transition: color var(--transition); }
-a:hover { color: var(--accent); }
+a { color: var(--accent); text-decoration: none; transition: color var(--transition); }
+a:hover { color: var(--accent-dark); }
+html[data-theme="light"] a:hover { color: var(--accent); }
 img { max-width: 100%; height: auto; display: block; }
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.001ms !important;
+    scroll-behavior: auto !important;
+  }
+}
 
 .container {
   max-width: var(--max-width);
@@ -127,7 +158,9 @@ img { max-width: 100%; height: auto; display: block; }
   z-index: 1000;
   display: flex;
   align-items: center;
+  transition: box-shadow var(--transition);
 }
+.navbar.scrolled { box-shadow: var(--shadow-sm); }
 
 .nav-inner {
   max-width: var(--max-width);
@@ -145,26 +178,34 @@ img { max-width: 100%; height: auto; display: block; }
   gap: 10px;
   text-decoration: none;
 }
-.nav-brand img { width: 32px; height: 32px; }
+.nav-brand img { width: 30px; height: 30px; }
 .nav-brand span {
-  font-family: var(--font-heading);
-  font-size: 1.2rem;
-  font-weight: 700;
+  font-family: var(--font-display);
+  font-size: 1.05rem;
+  font-weight: 600;
   color: var(--text-primary);
-  letter-spacing: -0.02em;
+  letter-spacing: -0.01em;
+}
+
+/* Groups nav-links + the persistent toggle/hamburger cluster so
+   nav-inner keeps a clean 2-item space-between (brand | everything else) */
+.nav-right {
+  display: flex;
+  align-items: center;
+  gap: 6px;
 }
 
 .nav-links {
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: 2px;
   list-style: none;
 }
 .nav-links a {
   color: var(--text-body);
-  font-size: 0.88rem;
+  font-size: 0.87rem;
   font-weight: 500;
-  padding: 8px 14px;
+  padding: 8px 13px;
   border-radius: var(--radius-sm);
   transition: all var(--transition);
 }
@@ -184,6 +225,7 @@ img { max-width: 100%; height: auto; display: block; }
   border-top: 4px solid currentColor;
   margin-left: 6px;
   vertical-align: middle;
+  opacity: 0.6;
 }
 .dropdown-menu {
   position: absolute;
@@ -194,10 +236,10 @@ img { max-width: 100%; height: auto; display: block; }
   border: 1px solid var(--surface-border);
   border-radius: var(--radius-md);
   box-shadow: var(--shadow-lg);
-  padding: 8px;
+  padding: 6px;
   opacity: 0;
   visibility: hidden;
-  transform: translateY(8px);
+  transform: translateY(6px);
   transition: all var(--transition);
   list-style: none;
 }
@@ -209,8 +251,8 @@ img { max-width: 100%; height: auto; display: block; }
 }
 .dropdown-menu a {
   display: block;
-  padding: 10px 14px;
-  font-size: 0.88rem;
+  padding: 9px 12px;
+  font-size: 0.87rem;
   color: var(--text-body);
   border-radius: var(--radius-sm);
 }
@@ -219,44 +261,52 @@ img { max-width: 100%; height: auto; display: block; }
   color: var(--text-primary);
 }
 
-/* Theme toggle */
-.theme-toggle-item { display: flex; align-items: center; }
-.theme-toggle {
+/* Theme toggle — a labelled switch, not a bare icon, so it reads
+   unambiguously and sits outside the collapsible menu on every
+   viewport: reachable in one tap whether the mobile menu is open
+   or closed. */
+.nav-controls {
   display: flex;
   align-items: center;
-  justify-content: center;
-  width: 38px;
+  gap: 8px;
+}
+.theme-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
   height: 38px;
-  border-radius: 50%;
+  padding: 0 13px;
+  border-radius: var(--radius-sm);
   border: 1px solid var(--surface-border);
   background: var(--bg-secondary);
   color: var(--text-primary);
+  font-family: var(--font-body);
+  font-size: 0.82rem;
+  font-weight: 600;
   cursor: pointer;
-  transition: all var(--transition);
   flex-shrink: 0;
+  transition: all var(--transition);
 }
 .theme-toggle:hover { border-color: var(--accent); color: var(--accent); }
-.theme-toggle svg { width: 18px; height: 18px; }
+.theme-toggle svg { width: 15px; height: 15px; flex-shrink: 0; }
 .theme-toggle .icon-moon { display: none; }
+.theme-toggle .tt-light { display: none; }
 html[data-theme="light"] .theme-toggle .icon-sun { display: none; }
 html[data-theme="light"] .theme-toggle .icon-moon { display: block; }
-
-@media (max-width: 900px) {
-  .theme-toggle-item { width: 100%; padding: 4px 14px; }
-  .theme-toggle { width: 44px; height: 44px; }
-}
+html[data-theme="light"] .theme-toggle .tt-dark { display: none; }
+html[data-theme="light"] .theme-toggle .tt-light { display: inline; }
 
 .nav-cta {
   background: var(--accent) !important;
-  color: #000 !important;
+  color: #06110B !important;
   font-weight: 600 !important;
-  padding: 8px 20px !important;
-  border-radius: 100px !important;
+  padding: 8px 18px !important;
+  border-radius: var(--radius-sm) !important;
   font-size: 0.85rem !important;
 }
 .nav-cta:hover {
   background: var(--accent-dark) !important;
-  color: #fff !important;
+  color: #06110B !important;
   transform: translateY(-1px);
 }
 
@@ -270,10 +320,11 @@ html[data-theme="light"] .theme-toggle .icon-moon { display: block; }
   z-index: 1001;
   background: none;
   border: none;
+  flex-shrink: 0;
 }
 .nav-hamburger span {
   display: block;
-  width: 22px;
+  width: 20px;
   height: 2px;
   background: var(--text-primary);
   border-radius: 2px;
@@ -285,23 +336,44 @@ html[data-theme="light"] .theme-toggle .icon-moon { display: block; }
 
 @media (max-width: 900px) {
   .nav-hamburger { display: flex; }
+  .theme-toggle { height: 42px; padding: 0 12px; font-size: 0.78rem; }
+
+  /* Full-screen takeover — a solid, considered panel rather than
+     a narrow translucent sidebar. */
   .nav-links {
     position: fixed;
-    top: 0; right: 0;
-    width: 280px;
-    height: 100vh;
+    top: var(--nav-height); left: 0; right: 0;
+    width: 100%;
+    height: calc(100vh - var(--nav-height));
     flex-direction: column;
+    justify-content: flex-start;
     background: var(--nav-bg-mobile);
-    backdrop-filter: blur(24px);
-    padding: 80px 24px 32px;
-    gap: 4px;
+    padding: 28px 24px 32px;
+    gap: 2px;
     transform: translateX(100%);
     transition: transform var(--transition);
-    border-left: 1px solid var(--surface-border);
     align-items: stretch;
+    overflow-y: auto;
   }
   .nav-links.open { transform: translateX(0); }
-  .nav-links a { width: 100%; padding: 12px 14px; font-size: 0.95rem; }
+  .nav-links a {
+    width: 100%;
+    padding: 15px 4px;
+    font-size: 1.05rem;
+    border-bottom: 1px solid var(--surface-border);
+    border-radius: 0;
+  }
+  .nav-links a:hover { background: none; color: var(--accent); }
+  .nav-links li:last-child a {
+    margin-top: 20px;
+    border: none;
+    background: var(--accent) !important;
+    color: #06110B !important;
+    text-align: center;
+    border-radius: var(--radius-sm) !important;
+    padding: 15px !important;
+  }
+  .nav-dropdown > a::after { float: right; margin-top: 4px; }
   .dropdown-menu {
     position: static;
     opacity: 1;
@@ -309,17 +381,22 @@ html[data-theme="light"] .theme-toggle .icon-moon { display: block; }
     transform: none;
     box-shadow: none;
     border: none;
-    padding: 0 0 0 16px;
+    padding: 0 0 4px 12px;
   }
+  .dropdown-menu a { border-bottom: none; padding: 10px 4px; font-size: 0.95rem; }
 }
 
-/* ── Buttons ── */
+/* ── Buttons ──
+   Framed like a command a person could select: bracket glyphs are
+   real content (::before/::after), not decoration bolted on after
+   the fact — they mark "this executes something", consistently,
+   everywhere a real action button appears. */
 .btn {
   display: inline-flex;
   align-items: center;
   gap: 8px;
-  padding: 12px 24px;
-  border-radius: 100px;
+  padding: 12px 20px;
+  border-radius: var(--radius-sm);
   font-family: var(--font-body);
   font-weight: 600;
   font-size: 0.9rem;
@@ -328,15 +405,20 @@ html[data-theme="light"] .theme-toggle .icon-moon { display: block; }
   text-decoration: none;
   transition: all var(--transition);
 }
+.btn::before { content: '['; opacity: 0.55; transition: margin var(--transition); margin-right: -2px; }
+.btn::after { content: ']'; opacity: 0.55; transition: margin var(--transition); margin-left: -2px; }
+.btn:hover::before { margin-right: 2px; }
+.btn:hover::after { margin-left: 2px; }
+.btn-sm { padding: 8px 16px; font-size: 0.8rem; }
 .btn-primary {
   background: var(--accent);
-  color: #000;
+  color: #06110B;
 }
 .btn-primary:hover {
   background: var(--accent-dark);
-  color: #fff;
+  color: #06110B;
   transform: translateY(-2px);
-  box-shadow: 0 0 20px rgba(16, 185, 129, 0.3);
+  box-shadow: 0 0 20px rgba(79, 190, 114, 0.25);
 }
 .btn-secondary {
   background: var(--bg-secondary);
@@ -369,35 +451,30 @@ html[data-theme="light"] .theme-toggle .icon-moon { display: block; }
 
 .hero-content { z-index: 1; }
 
+/* Eyebrow tag: no pill, no border-box — a small prompt-style line,
+   the same device used for every section label on the page. */
 .hero-badge {
   display: inline-flex;
   align-items: center;
   gap: 8px;
-  padding: 6px 16px;
-  background: var(--accent-light);
-  border: 1px solid #a7f3d0;
-  border-radius: 100px;
+  font-family: var(--font-display);
   font-size: 0.78rem;
   font-weight: 600;
-  color: var(--accent-dark);
-  margin-bottom: 24px;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
+  color: var(--accent);
+  margin-bottom: 22px;
+  letter-spacing: 0.02em;
 }
+.hero-badge::before { content: '$'; opacity: 0.6; }
 .hero-badge .pulse {
-  width: 8px; height: 8px;
-  background: var(--accent);
+  width: 7px; height: 7px;
+  background: var(--bugdroid);
   border-radius: 50%;
   animation: pulse 2s ease-in-out infinite;
+  flex-shrink: 0;
 }
 
-.hero h1 { margin-bottom: 20px; font-weight: 800; }
-.hero h1 .gradient-text {
-  background: linear-gradient(135deg, var(--accent-dark), #0ea5e9);
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
-}
+.hero h1 { margin-bottom: 20px; }
+.hero h1 .gradient-text { color: var(--accent); }
 
 .hero-description {
   font-size: 1.08rem;
@@ -415,16 +492,16 @@ html[data-theme="light"] .theme-toggle .icon-moon { display: block; }
   align-items: center;
 }
 
-/* Premium Device Frame Mockup */
+/* Device Frame Mockup */
 .device-frame-wrapper {
   position: relative;
   width: 100%;
   max-width: 480px;
   padding: 10px;
-  background: #121214;
+  background: #0E120E;
   border-radius: 36px;
-  border: 4px solid #27272a;
-  box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.5), inset 0 1px 0 rgba(255, 255, 255, 0.1);
+  border: 4px solid #232B21;
+  box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.5), inset 0 1px 0 rgba(255, 255, 255, 0.06);
   overflow: hidden;
 }
 
@@ -443,10 +520,6 @@ html[data-theme="light"] .theme-toggle .icon-moon { display: block; }
   object-fit: cover;
 }
 
-@keyframes float {
-  0%, 100% { transform: translateY(0); }
-  50% { transform: translateY(-12px); }
-}
 @keyframes pulse {
   0%, 100% { opacity: 1; transform: scale(1); }
   50% { opacity: 0.5; transform: scale(0.85); }
@@ -475,29 +548,33 @@ html[data-theme="light"] .theme-toggle .icon-moon { display: block; }
   max-width: 600px;
   margin: 0 auto 56px;
 }
-.section-header .label {
-  display: inline-block;
-  font-size: 0.75rem;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.1em;
-  color: var(--accent-dark);
-  margin-bottom: 12px;
+.section-header .label, .page-header .label {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-family: var(--font-display);
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: var(--accent);
+  margin-bottom: 14px;
+  letter-spacing: 0.02em;
 }
+.section-header .label::before, .page-header .label::before { content: '$'; opacity: 0.6; }
 .section-header h2 { margin-bottom: 14px; }
 .section-header p { color: var(--text-muted); font-size: 1rem; }
 
-/* ── Cards ── */
+/* ── Cards ──
+   A crisp, solid surface — the frosted-glass treatment is spent
+   once, deliberately, on the architecture diagram below, rather
+   than on every card on the page. */
 .glass-card {
-  background: var(--glass-bg);
+  background: var(--surface);
   border: 1px solid var(--surface-border);
   border-radius: var(--radius-lg);
-  padding: 28px;
+  padding: 26px;
   transition: all var(--transition);
   position: relative;
   overflow: hidden;
-  backdrop-filter: blur(8px);
-  -webkit-backdrop-filter: blur(8px);
 }
 .glass-card:hover {
   border-color: var(--hover-border);
@@ -549,9 +626,9 @@ html[data-theme="light"] .theme-toggle .icon-moon { display: block; }
 }
 .stat { text-align: center; }
 .stat .number {
-  font-family: var(--font-heading);
-  font-size: 2.2rem;
-  font-weight: 800;
+  font-family: var(--font-display);
+  font-size: 2.1rem;
+  font-weight: 600;
   color: var(--text-primary);
   line-height: 1;
 }
@@ -561,7 +638,7 @@ html[data-theme="light"] .theme-toggle .icon-moon { display: block; }
   margin-top: 6px;
 }
 
-/* ── Architecture Flow Diagram styling ── */
+/* ── Architecture Flow Diagram — the one deliberate glass moment ── */
 .arch-diagram-wrapper {
   margin-top: 32px;
   background: var(--glass-bg);
@@ -571,8 +648,8 @@ html[data-theme="light"] .theme-toggle .icon-moon { display: block; }
   display: flex;
   justify-content: center;
   align-items: center;
-  backdrop-filter: blur(8px);
-  -webkit-backdrop-filter: blur(8px);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
   box-shadow: var(--shadow-lg);
   overflow-x: auto;
 }
@@ -609,9 +686,7 @@ html[data-theme="light"] .theme-toggle .icon-moon { display: block; }
 }
 
 @keyframes flowAnim {
-  to {
-    stroke-dashoffset: -20;
-  }
+  to { stroke-dashoffset: -20; }
 }
 
 /* ── CTA ── */
@@ -646,17 +721,18 @@ html[data-theme="light"] .theme-toggle .icon-moon { display: block; }
 }
 .footer-brand p { color: var(--text-muted); font-size: 0.88rem; margin-top: 12px; max-width: 280px; }
 .footer-col h4 {
-  font-size: 0.8rem;
+  font-family: var(--font-display);
+  font-size: 0.78rem;
   font-weight: 600;
   text-transform: uppercase;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.06em;
   color: var(--text-primary);
   margin-bottom: 14px;
 }
 .footer-col ul { list-style: none; }
 .footer-col li { margin-bottom: 8px; }
 .footer-col a { color: var(--text-muted); font-size: 0.88rem; }
-.footer-col a:hover { color: var(--accent-dark); }
+.footer-col a:hover { color: var(--accent); }
 .footer-bottom {
   border-top: 1px solid var(--surface-border);
   padding-top: 20px;
@@ -681,15 +757,6 @@ html[data-theme="light"] .theme-toggle .icon-moon { display: block; }
 @media (max-width: 600px) {
   .page-header { padding: 100px 0 36px; }
 }
-.page-header .label {
-  display: inline-block;
-  font-size: 0.75rem;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.1em;
-  color: var(--accent-dark);
-  margin-bottom: 12px;
-}
 .page-header h1 { margin-bottom: 14px; }
 .page-header p { color: var(--text-muted); max-width: 540px; margin: 0 auto; }
 
@@ -699,17 +766,17 @@ html[data-theme="light"] .theme-toggle .icon-moon { display: block; }
   padding: 40px 24px 80px;
 }
 .prose h2 {
-  font-size: 1.4rem;
+  font-size: 1.3rem;
   margin-top: 40px;
   margin-bottom: 14px;
   padding-bottom: 8px;
   border-bottom: 1px solid var(--surface-border);
 }
 .prose h3 {
-  font-size: 1.1rem;
+  font-size: 1.05rem;
   margin-top: 28px;
   margin-bottom: 10px;
-  color: var(--accent-dark);
+  color: var(--accent);
 }
 .prose p, .prose li {
   color: var(--text-body);
@@ -772,11 +839,12 @@ html[data-theme="light"] .theme-toggle .icon-moon { display: block; }
 .showcase-card p { color: var(--text-muted); font-size: 0.9rem; margin-bottom: 0; }
 .showcase-card .tag-row { display: flex; gap: 6px; flex-wrap: wrap; margin-top: 10px; }
 .showcase-card .tag {
+  font-family: var(--font-display);
   font-size: 0.7rem;
-  padding: 3px 10px;
+  padding: 3px 9px;
   background: var(--bg-secondary);
   border: 1px solid var(--surface-border);
-  border-radius: 100px;
+  border-radius: var(--radius-sm);
   color: var(--text-muted);
   font-weight: 500;
 }
@@ -814,8 +882,9 @@ html[data-theme="light"] .theme-toggle .icon-moon { display: block; }
 }
 .faq-question .chevron {
   transition: transform var(--transition);
-  font-size: 0.8rem;
-  color: var(--accent-dark);
+  font-family: var(--font-display);
+  font-size: 0.85rem;
+  color: var(--accent);
 }
 .faq-item.open .faq-question .chevron { transform: rotate(180deg); }
 .faq-answer { max-height: 0; overflow: hidden; transition: max-height 0.4s ease; }
@@ -856,19 +925,19 @@ html[data-theme="light"] .theme-toggle .icon-moon { display: block; }
 .version-table td { color: var(--text-body); }
 .badge-supported {
   display: inline-block;
-  padding: 3px 12px;
+  padding: 3px 11px;
   background: var(--accent-light);
-  color: var(--accent-dark);
-  border-radius: 100px;
+  color: var(--accent);
+  border-radius: var(--radius-sm);
   font-size: 0.75rem;
   font-weight: 600;
 }
 .badge-unsupported {
   display: inline-block;
-  padding: 3px 12px;
+  padding: 3px 11px;
   background: var(--danger-bg);
   color: var(--danger-text);
-  border-radius: 100px;
+  border-radius: var(--radius-sm);
   font-size: 0.75rem;
   font-weight: 600;
 }
@@ -955,26 +1024,6 @@ html[data-theme="light"] .theme-toggle .icon-moon { display: block; }
   margin: 0 auto;
 }
 
-.video-glow {
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  width: 80%;
-  height: 80%;
-  background: radial-gradient(ellipse, rgba(16,185,129,0.15) 0%, rgba(14,165,233,0.08) 40%, transparent 70%);
-  border-radius: 50%;
-  filter: blur(40px);
-  z-index: 0;
-  pointer-events: none;
-  animation: glowPulse 4s ease-in-out infinite;
-}
-
-@keyframes glowPulse {
-  0%, 100% { opacity: 0.7; transform: translate(-50%, -50%) scale(1); }
-  50% { opacity: 1; transform: translate(-50%, -50%) scale(1.05); }
-}
-
 .video-container {
   position: relative;
   z-index: 1;
@@ -988,7 +1037,7 @@ html[data-theme="light"] .theme-toggle .icon-moon { display: block; }
 
 .video-container:hover {
   transform: translateY(-6px);
-  box-shadow: 0 20px 60px rgba(16,185,129,0.15), var(--shadow-lg);
+  box-shadow: 0 20px 60px rgba(79,190,114,0.15), var(--shadow-lg);
   border-color: var(--accent);
 }
 
@@ -1009,12 +1058,8 @@ html[data-theme="light"] .theme-toggle .icon-moon { display: block; }
 }
 
 @media (max-width: 600px) {
-  .video-showcase {
-    max-width: 100%;
-  }
-  .video-container {
-    border-radius: var(--radius-lg);
-  }
+  .video-showcase { max-width: 100%; }
+  .video-container { border-radius: var(--radius-lg); }
 }
 
 /* ── Reveal animation ── */
@@ -1031,3 +1076,172 @@ html[data-theme="light"] .theme-toggle .icon-moon { display: block; }
 /* ── Utilities ── */
 .text-center { text-align: center; }
 .mt-4 { margin-top: 2rem; }
+
+/* ── Contributor / Tester profile cards ──
+   Previously duplicated as a page-level <style> block on
+   contributor.html with hardcoded blue/amber hex that ignored
+   the theme system entirely. Consolidated here as the single
+   source of truth, retoned to the site's actual palette. */
+.profile-section { padding: 60px 0; }
+.profile-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 28px;
+  margin-top: 30px;
+}
+@media (max-width: 992px) {
+  .profile-grid { grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); }
+}
+.profile-card {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  padding: 30px;
+  background: var(--surface);
+  border: 1px solid var(--surface-border);
+  border-radius: var(--radius-lg);
+  transition: all var(--transition);
+  position: relative;
+  overflow: hidden;
+  box-shadow: var(--shadow-sm);
+}
+.profile-card::before {
+  content: '';
+  position: absolute;
+  top: 0; left: 0; right: 0; height: 3px;
+  background: linear-gradient(90deg, var(--accent) 0%, var(--bugdroid) 100%);
+  opacity: 0.7;
+}
+.profile-card:hover {
+  transform: translateY(-5px);
+  box-shadow: var(--shadow-lg);
+  border-color: var(--hover-border);
+}
+.profile-header {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  margin-bottom: 18px;
+}
+.avatar-wrapper {
+  position: relative;
+  width: 72px;
+  height: 72px;
+  border-radius: 50%;
+  padding: 3px;
+  background: linear-gradient(135deg, var(--accent) 0%, var(--bugdroid) 100%);
+  flex-shrink: 0;
+}
+.avatar-img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: 50%;
+  border: 3px solid var(--surface);
+  transition: transform var(--transition);
+}
+.profile-card:hover .avatar-img { transform: scale(1.04); }
+.status-badge {
+  position: absolute;
+  bottom: -2px;
+  right: -2px;
+  background: var(--accent);
+  color: #06110B;
+  font-size: 0.62rem;
+  font-weight: 700;
+  padding: 3px 8px;
+  border-radius: var(--radius-sm);
+  border: 2px solid var(--surface);
+}
+.profile-titles h3 { font-size: 1.15rem; margin-bottom: 2px; }
+.profile-username {
+  font-size: 0.85rem;
+  color: var(--accent);
+  font-weight: 600;
+}
+.profile-username:hover { color: var(--accent-dark); }
+html[data-theme="light"] .profile-username:hover { color: var(--accent); }
+.profile-body { flex-grow: 1; }
+.profile-badges { display: flex; flex-wrap: wrap; gap: 6px; margin-bottom: 16px; }
+/* One quiet chip style for every role — the label text carries the
+   meaning, not a different candy color per role. */
+.role-badge {
+  font-size: 0.7rem;
+  font-weight: 600;
+  padding: 4px 10px;
+  border-radius: var(--radius-sm);
+  background: var(--bg-secondary);
+  border: 1px solid var(--surface-border);
+  color: var(--text-body);
+}
+.profile-bio { font-size: 0.9rem; color: var(--text-body); line-height: 1.6; margin-bottom: 20px; }
+.profile-achievements {
+  margin-bottom: 20px;
+  border-top: 1px solid var(--surface-border);
+  padding-top: 16px;
+}
+.ach-title {
+  font-family: var(--font-display);
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-muted);
+  margin-bottom: 10px;
+  font-weight: 600;
+}
+.ach-list { display: flex; flex-wrap: wrap; gap: 6px; }
+.ach-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--surface-border);
+  padding: 4px 8px;
+  border-radius: var(--radius-sm);
+  font-size: 0.72rem;
+  font-weight: 500;
+  color: var(--text-body);
+}
+.ach-badge:hover { background: var(--bg-tertiary); border-color: var(--hover-border); }
+.ach-badge img { width: 14px; height: 14px; object-fit: contain; }
+.profile-stats {
+  display: flex;
+  gap: 20px;
+  margin-bottom: 24px;
+  border-top: 1px solid var(--surface-border);
+  padding-top: 16px;
+}
+.stat-item { display: flex; flex-direction: column; }
+.stat-num { font-size: 1.05rem; font-weight: 700; color: var(--text-primary); }
+.stat-label { font-size: 0.72rem; color: var(--text-muted); }
+.profile-footer {
+  border-top: 1px solid var(--surface-border);
+  padding-top: 20px;
+  margin-top: auto;
+  display: flex;
+  gap: 10px;
+}
+
+/* Call-to-action card inside the profile grid */
+.join-card {
+  border: 2px dashed var(--surface-border);
+  background: transparent;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  min-height: 300px;
+}
+.join-card::before { display: none; }
+.join-card:hover { border-color: var(--accent); background: var(--accent-light); transform: translateY(-4px); }
+.join-icon { font-size: 2.1rem; margin-bottom: 12px; display: block; }
+.join-card h3 { font-size: 1.1rem; margin-bottom: 8px; }
+.join-card p { font-size: 0.88rem; color: var(--text-muted); max-width: 250px; margin: 0 auto 20px; }
+
+/* Section divider — previously an empty div with no matching rule
+   anywhere, so it rendered as nothing. */
+.divider {
+  height: 1px;
+  background: var(--surface-border);
+  margin: 0 auto;
+  max-width: var(--max-width);
+}

--- a/website/css/style.css
+++ b/website/css/style.css
@@ -25,6 +25,50 @@
   --nav-height: 64px;
   --max-width: 1140px;
   --transition: 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+
+  /* Theme-dependent surfaces (dark = default) */
+  --nav-bg: rgba(9, 9, 11, 0.8);
+  --nav-bg-mobile: rgba(9, 9, 11, 0.95);
+  --glass-bg: rgba(24, 24, 27, 0.7);
+  --hover-border: rgba(255, 255, 255, 0.15);
+  --node-fill: #18181b;
+  --node-fill-hover: #27272a;
+  --danger-bg: rgba(239, 68, 68, 0.12);
+  --danger-text: #f87171;
+}
+
+/* ── Light theme ── */
+html[data-theme="light"] {
+  --bg-primary: #ffffff;
+  --bg-secondary: #f6f7f8;
+  --bg-tertiary: #eef0f2;
+  --surface: #ffffff;
+  --surface-hover: #eef0f2;
+  --surface-border: rgba(0, 0, 0, 0.09);
+  --accent: #059669;
+  --accent-light: rgba(5, 150, 105, 0.1);
+  --accent-dark: #047857;
+  --text-primary: #18181b;
+  --text-body: #52525b;
+  --text-muted: #71717a;
+  --shadow-sm: 0 1px 2px rgba(0,0,0,0.06);
+  --shadow-md: 0 4px 12px rgba(0,0,0,0.08);
+  --shadow-lg: 0 12px 40px rgba(0,0,0,0.12);
+
+  --nav-bg: rgba(255, 255, 255, 0.85);
+  --nav-bg-mobile: rgba(255, 255, 255, 0.97);
+  --glass-bg: rgba(255, 255, 255, 0.7);
+  --hover-border: rgba(0, 0, 0, 0.15);
+  --node-fill: #f6f7f8;
+  --node-fill-hover: #eef0f2;
+  --danger-bg: #fee2e2;
+  --danger-text: #dc2626;
+}
+
+/* Smooth transition when switching themes */
+body, .navbar, .nav-links, .glass-card, .btn-secondary, .faq-item,
+.arch-svg .node-rect, .badge-unsupported {
+  transition: background-color var(--transition), border-color var(--transition), color var(--transition);
 }
 
 /* ── Keyboard Focus Styles ── */
@@ -67,13 +111,16 @@ img { max-width: 100%; height: auto; display: block; }
   padding: 0 24px;
   position: relative;
 }
+@media (max-width: 380px) {
+  .container { padding: 0 16px; }
+}
 
 /* ── Navigation ── */
 .navbar {
   position: fixed;
   top: 0; left: 0; right: 0;
   height: var(--nav-height);
-  background: rgba(9, 9, 11, 0.8);
+  background: var(--nav-bg);
   backdrop-filter: blur(12px);
   -webkit-backdrop-filter: blur(12px);
   border-bottom: 1px solid var(--surface-border);
@@ -172,6 +219,33 @@ img { max-width: 100%; height: auto; display: block; }
   color: var(--text-primary);
 }
 
+/* Theme toggle */
+.theme-toggle-item { display: flex; align-items: center; }
+.theme-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 38px;
+  height: 38px;
+  border-radius: 50%;
+  border: 1px solid var(--surface-border);
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  cursor: pointer;
+  transition: all var(--transition);
+  flex-shrink: 0;
+}
+.theme-toggle:hover { border-color: var(--accent); color: var(--accent); }
+.theme-toggle svg { width: 18px; height: 18px; }
+.theme-toggle .icon-moon { display: none; }
+html[data-theme="light"] .theme-toggle .icon-sun { display: none; }
+html[data-theme="light"] .theme-toggle .icon-moon { display: block; }
+
+@media (max-width: 900px) {
+  .theme-toggle-item { width: 100%; padding: 4px 14px; }
+  .theme-toggle { width: 44px; height: 44px; }
+}
+
 .nav-cta {
   background: var(--accent) !important;
   color: #000 !important;
@@ -217,7 +291,7 @@ img { max-width: 100%; height: auto; display: block; }
     width: 280px;
     height: 100vh;
     flex-direction: column;
-    background: rgba(9, 9, 11, 0.95);
+    background: var(--nav-bg-mobile);
     backdrop-filter: blur(24px);
     padding: 80px 24px 32px;
     gap: 4px;
@@ -271,7 +345,7 @@ img { max-width: 100%; height: auto; display: block; }
 }
 .btn-secondary:hover {
   background: var(--surface-hover);
-  border-color: rgba(255, 255, 255, 0.2);
+  border-color: var(--hover-border);
   color: var(--text-primary);
   transform: translateY(-2px);
 }
@@ -391,6 +465,10 @@ img { max-width: 100%; height: auto; display: block; }
   padding: 80px 0;
   position: relative;
 }
+@media (max-width: 600px) {
+  .section { padding: 48px 0; }
+  .section-header { margin-bottom: 36px; }
+}
 
 .section-header {
   text-align: center;
@@ -411,7 +489,7 @@ img { max-width: 100%; height: auto; display: block; }
 
 /* ── Cards ── */
 .glass-card {
-  background: rgba(24, 24, 27, 0.7); /* Translucent dark zinc */
+  background: var(--glass-bg);
   border: 1px solid var(--surface-border);
   border-radius: var(--radius-lg);
   padding: 28px;
@@ -422,9 +500,9 @@ img { max-width: 100%; height: auto; display: block; }
   -webkit-backdrop-filter: blur(8px);
 }
 .glass-card:hover {
-  border-color: rgba(255, 255, 255, 0.15);
+  border-color: var(--hover-border);
   transform: translateY(-2px);
-  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.4);
+  box-shadow: var(--shadow-md);
 }
 
 /* ── Feature Grid ── */
@@ -486,7 +564,7 @@ img { max-width: 100%; height: auto; display: block; }
 /* ── Architecture Flow Diagram styling ── */
 .arch-diagram-wrapper {
   margin-top: 32px;
-  background: rgba(24, 24, 27, 0.7);
+  background: var(--glass-bg);
   border: 1px solid var(--surface-border);
   border-radius: var(--radius-xl);
   padding: 40px;
@@ -512,7 +590,7 @@ img { max-width: 100%; height: auto; display: block; }
 }
 
 .arch-svg .node-rect {
-  fill: #18181b;
+  fill: var(--node-fill);
   stroke: var(--surface-border);
   stroke-width: 1.5;
   transition: all 0.3s ease;
@@ -520,7 +598,7 @@ img { max-width: 100%; height: auto; display: block; }
 
 .arch-svg .node-rect:hover {
   stroke: var(--accent);
-  fill: #27272a;
+  fill: var(--node-fill-hover);
 }
 
 .arch-svg .flow-line {
@@ -546,6 +624,9 @@ img { max-width: 100%; height: auto; display: block; }
   border: 1px solid var(--surface-border);
   border-radius: var(--radius-xl);
   padding: 56px 40px;
+}
+@media (max-width: 600px) {
+  .cta-box { padding: 36px 22px; }
 }
 .cta-box h2 { margin-bottom: 14px; }
 .cta-box p { color: var(--text-muted); margin-bottom: 28px; max-width: 480px; margin-left: auto; margin-right: auto; }
@@ -596,6 +677,9 @@ img { max-width: 100%; height: auto; display: block; }
   padding: 120px 0 48px;
   text-align: center;
   background: var(--bg-secondary);
+}
+@media (max-width: 600px) {
+  .page-header { padding: 100px 0 36px; }
 }
 .page-header .label {
   display: inline-block;
@@ -712,7 +796,7 @@ img { max-width: 100%; height: auto; display: block; }
   background: var(--surface);
   transition: all var(--transition);
 }
-.faq-item:hover { border-color: #d1d5db; }
+.faq-item:hover { border-color: var(--hover-border); }
 .faq-question {
   padding: 18px 20px;
   cursor: pointer;
@@ -782,8 +866,8 @@ img { max-width: 100%; height: auto; display: block; }
 .badge-unsupported {
   display: inline-block;
   padding: 3px 12px;
-  background: #fee2e2;
-  color: #dc2626;
+  background: var(--danger-bg);
+  color: var(--danger-text);
   border-radius: 100px;
   font-size: 0.75rem;
   font-weight: 600;
@@ -947,6 +1031,3 @@ img { max-width: 100%; height: auto; display: block; }
 /* ── Utilities ── */
 .text-center { text-align: center; }
 .mt-4 { margin-top: 2rem; }
-
-/* Hidden particle canvas */
-#particles-canvas { display: none; }

--- a/website/features.html
+++ b/website/features.html
@@ -25,17 +25,8 @@
       <img src="assets/bot.png" alt="OpenDroid">
       <span>OpenDroid</span>
     </a>
-    <button class="nav-hamburger" id="nav-hamburger" aria-label="Toggle menu">
-      <span></span><span></span><span></span>
-    </button>
+    <div class="nav-right">
     <ul class="nav-links" id="nav-links">
-      <li class="theme-toggle-item">
-        <button class="theme-toggle" id="theme-toggle" type="button" aria-label="Activer le mode clair" aria-pressed="false">
-          <svg class="icon-sun" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"></circle><line x1="12" y1="1" x2="12" y2="3"></line><line x1="12" y1="21" x2="12" y2="23"></line><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line><line x1="1" y1="12" x2="3" y2="12"></line><line x1="21" y1="12" x2="23" y2="12"></line><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line></svg>
-          <svg class="icon-moon" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path></svg>
-        </button>
-      </li>
-
       <li class="nav-dropdown">
         <a href="features.html">Products</a>
         <ul class="dropdown-menu">
@@ -65,8 +56,21 @@
           <li><a href="privacy.html">Privacy</a></li>
         </ul>
       </li>
-      <li><a href="https://github.com/yashab-cyber/opendroid/releases" target="_blank" class="nav-cta">Download ↓</a></li>
+      <li><a href="https://github.com/yashab-cyber/opendroid/releases" target="_blank" class="nav-cta" aria-label="Download OpenDroid">
+        Download
+        <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align: middle; margin-left: 4px;"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path><polyline points="7 10 12 15 17 10"></polyline><line x1="12" y1="15" x2="12" y2="3"></line></svg>
+      </a></li>
     </ul>
+    <div class="nav-controls">
+      <button class="theme-toggle" id="theme-toggle" type="button" aria-label="Enable light mode" aria-pressed="false">
+        <svg class="icon-sun" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"></circle><line x1="12" y1="1" x2="12" y2="3"></line><line x1="12" y1="21" x2="12" y2="23"></line><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line><line x1="1" y1="12" x2="3" y2="12"></line><line x1="21" y1="12" x2="23" y2="12"></line><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line></svg>
+        <svg class="icon-moon" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path></svg>
+        <span class="theme-toggle-text-wrap"><span class="tt-dark">Dark</span><span class="tt-light">Light</span></span>
+      </button>
+      <button class="nav-hamburger" id="nav-hamburger" aria-label="Toggle menu">
+        <span></span><span></span><span></span>
+      </button>
+    </div>
   </div>
 </nav>
 

--- a/website/features.html
+++ b/website/features.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <script>document.documentElement.setAttribute('data-theme', localStorage.getItem('opendroid-theme') || 'dark');</script>
+
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Features — OpenDroid</title>
@@ -27,6 +29,13 @@
       <span></span><span></span><span></span>
     </button>
     <ul class="nav-links" id="nav-links">
+      <li class="theme-toggle-item">
+        <button class="theme-toggle" id="theme-toggle" type="button" aria-label="Activer le mode clair" aria-pressed="false">
+          <svg class="icon-sun" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"></circle><line x1="12" y1="1" x2="12" y2="3"></line><line x1="12" y1="21" x2="12" y2="23"></line><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line><line x1="1" y1="12" x2="3" y2="12"></line><line x1="21" y1="12" x2="23" y2="12"></line><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line></svg>
+          <svg class="icon-moon" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path></svg>
+        </button>
+      </li>
+
       <li class="nav-dropdown">
         <a href="features.html">Products</a>
         <ul class="dropdown-menu">

--- a/website/index.html
+++ b/website/index.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <script>document.documentElement.setAttribute('data-theme', localStorage.getItem('opendroid-theme') || 'dark');</script>
+
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>OpenDroid — Your Open Autonomous Android Agent</title>
@@ -22,8 +24,6 @@
 </head>
 <body>
 
-<canvas id="particles-canvas"></canvas>
-
 <!-- Navigation -->
 <nav class="navbar" id="navbar">
   <div class="nav-inner">
@@ -35,6 +35,13 @@
       <span></span><span></span><span></span>
     </button>
     <ul class="nav-links" id="nav-links">
+      <li class="theme-toggle-item">
+        <button class="theme-toggle" id="theme-toggle" type="button" aria-label="Activer le mode clair" aria-pressed="false">
+          <svg class="icon-sun" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"></circle><line x1="12" y1="1" x2="12" y2="3"></line><line x1="12" y1="21" x2="12" y2="23"></line><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line><line x1="1" y1="12" x2="3" y2="12"></line><line x1="21" y1="12" x2="23" y2="12"></line><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line></svg>
+          <svg class="icon-moon" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path></svg>
+        </button>
+      </li>
+
       <li class="nav-dropdown">
         <a href="features.html">Products</a>
         <ul class="dropdown-menu">

--- a/website/index.html
+++ b/website/index.html
@@ -31,17 +31,8 @@
       <img src="assets/bot.png" alt="OpenDroid">
       <span>OpenDroid</span>
     </a>
-    <button class="nav-hamburger" id="nav-hamburger" aria-label="Toggle menu">
-      <span></span><span></span><span></span>
-    </button>
+    <div class="nav-right">
     <ul class="nav-links" id="nav-links">
-      <li class="theme-toggle-item">
-        <button class="theme-toggle" id="theme-toggle" type="button" aria-label="Activer le mode clair" aria-pressed="false">
-          <svg class="icon-sun" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"></circle><line x1="12" y1="1" x2="12" y2="3"></line><line x1="12" y1="21" x2="12" y2="23"></line><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line><line x1="1" y1="12" x2="3" y2="12"></line><line x1="21" y1="12" x2="23" y2="12"></line><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line></svg>
-          <svg class="icon-moon" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path></svg>
-        </button>
-      </li>
-
       <li class="nav-dropdown">
         <a href="features.html">Products</a>
         <ul class="dropdown-menu">
@@ -77,6 +68,16 @@
         <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align: middle; margin-left: 4px;"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path><polyline points="7 10 12 15 17 10"></polyline><line x1="12" y1="15" x2="12" y2="3"></line></svg>
       </a></li>
     </ul>
+    <div class="nav-controls">
+      <button class="theme-toggle" id="theme-toggle" type="button" aria-label="Enable light mode" aria-pressed="false">
+        <svg class="icon-sun" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"></circle><line x1="12" y1="1" x2="12" y2="3"></line><line x1="12" y1="21" x2="12" y2="23"></line><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line><line x1="1" y1="12" x2="3" y2="12"></line><line x1="21" y1="12" x2="23" y2="12"></line><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line></svg>
+        <svg class="icon-moon" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path></svg>
+        <span class="theme-toggle-text-wrap"><span class="tt-dark">Dark</span><span class="tt-light">Light</span></span>
+      </button>
+      <button class="nav-hamburger" id="nav-hamburger" aria-label="Toggle menu">
+        <span></span><span></span><span></span>
+      </button>
+    </div>
   </div>
 </nav>
 
@@ -130,7 +131,6 @@
       <p>Watch OpenDroid come to life with a friendly greeting, rendered in stunning 3D.</p>
     </div>
     <div class="video-showcase reveal">
-      <div class="video-glow"></div>
       <div class="video-container">
         <video autoplay muted loop playsinline id="hero-video">
           <source src="assets/opendroid-3d-hello.mp4" type="video/mp4">

--- a/website/js/main.js
+++ b/website/js/main.js
@@ -1,3 +1,25 @@
+// ── Theme Toggle ──
+(function () {
+  const toggle = document.getElementById('theme-toggle');
+  if (!toggle) return;
+  const root = document.documentElement;
+  const STORAGE_KEY = 'opendroid-theme';
+
+  const updateA11y = () => {
+    const isLight = root.getAttribute('data-theme') === 'light';
+    toggle.setAttribute('aria-pressed', String(isLight));
+    toggle.setAttribute('aria-label', isLight ? 'Activer le mode sombre' : 'Activer le mode clair');
+  };
+  updateA11y();
+
+  toggle.addEventListener('click', () => {
+    const next = root.getAttribute('data-theme') === 'light' ? 'dark' : 'light';
+    root.setAttribute('data-theme', next);
+    try { localStorage.setItem(STORAGE_KEY, next); } catch (e) { /* storage unavailable, ignore */ }
+    updateA11y();
+  });
+})();
+
 // ── Hamburger Menu ──
 const hamburger = document.getElementById('nav-hamburger');
 const navLinks = document.getElementById('nav-links');

--- a/website/js/main.js
+++ b/website/js/main.js
@@ -8,7 +8,7 @@
   const updateA11y = () => {
     const isLight = root.getAttribute('data-theme') === 'light';
     toggle.setAttribute('aria-pressed', String(isLight));
-    toggle.setAttribute('aria-label', isLight ? 'Activer le mode sombre' : 'Activer le mode clair');
+    toggle.setAttribute('aria-label', isLight ? 'Enable dark mode' : 'Enable light mode');
   };
   updateA11y();
 
@@ -68,10 +68,6 @@ document.querySelectorAll('.faq-question').forEach(btn => {
 const navbar = document.getElementById('navbar');
 if (navbar) {
   window.addEventListener('scroll', () => {
-    if (window.scrollY > 10) {
-      navbar.style.boxShadow = '0 1px 8px rgba(0,0,0,0.06)';
-    } else {
-      navbar.style.boxShadow = 'none';
-    }
+    navbar.classList.toggle('scrolled', window.scrollY > 10);
   });
 }

--- a/website/privacy.html
+++ b/website/privacy.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <script>document.documentElement.setAttribute('data-theme', localStorage.getItem('opendroid-theme') || 'dark');</script>
+
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Privacy Policy — OpenDroid</title>
@@ -27,6 +29,13 @@
       <span></span><span></span><span></span>
     </button>
     <ul class="nav-links" id="nav-links">
+      <li class="theme-toggle-item">
+        <button class="theme-toggle" id="theme-toggle" type="button" aria-label="Activer le mode clair" aria-pressed="false">
+          <svg class="icon-sun" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"></circle><line x1="12" y1="1" x2="12" y2="3"></line><line x1="12" y1="21" x2="12" y2="23"></line><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line><line x1="1" y1="12" x2="3" y2="12"></line><line x1="21" y1="12" x2="23" y2="12"></line><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line></svg>
+          <svg class="icon-moon" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path></svg>
+        </button>
+      </li>
+
       <li class="nav-dropdown">
         <a href="features.html">Products</a>
         <ul class="dropdown-menu">

--- a/website/privacy.html
+++ b/website/privacy.html
@@ -25,17 +25,8 @@
       <img src="assets/bot.png" alt="OpenDroid">
       <span>OpenDroid</span>
     </a>
-    <button class="nav-hamburger" id="nav-hamburger" aria-label="Toggle menu">
-      <span></span><span></span><span></span>
-    </button>
+    <div class="nav-right">
     <ul class="nav-links" id="nav-links">
-      <li class="theme-toggle-item">
-        <button class="theme-toggle" id="theme-toggle" type="button" aria-label="Activer le mode clair" aria-pressed="false">
-          <svg class="icon-sun" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"></circle><line x1="12" y1="1" x2="12" y2="3"></line><line x1="12" y1="21" x2="12" y2="23"></line><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line><line x1="1" y1="12" x2="3" y2="12"></line><line x1="21" y1="12" x2="23" y2="12"></line><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line></svg>
-          <svg class="icon-moon" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path></svg>
-        </button>
-      </li>
-
       <li class="nav-dropdown">
         <a href="features.html">Products</a>
         <ul class="dropdown-menu">
@@ -70,6 +61,16 @@
         <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align: middle; margin-left: 4px;"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path><polyline points="7 10 12 15 17 10"></polyline><line x1="12" y1="15" x2="12" y2="3"></line></svg>
       </a></li>
     </ul>
+    <div class="nav-controls">
+      <button class="theme-toggle" id="theme-toggle" type="button" aria-label="Enable light mode" aria-pressed="false">
+        <svg class="icon-sun" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"></circle><line x1="12" y1="1" x2="12" y2="3"></line><line x1="12" y1="21" x2="12" y2="23"></line><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line><line x1="1" y1="12" x2="3" y2="12"></line><line x1="21" y1="12" x2="23" y2="12"></line><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line></svg>
+        <svg class="icon-moon" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path></svg>
+        <span class="theme-toggle-text-wrap"><span class="tt-dark">Dark</span><span class="tt-light">Light</span></span>
+      </button>
+      <button class="nav-hamburger" id="nav-hamburger" aria-label="Toggle menu">
+        <span></span><span></span><span></span>
+      </button>
+    </div>
   </div>
 </nav>
 

--- a/website/security.html
+++ b/website/security.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <script>document.documentElement.setAttribute('data-theme', localStorage.getItem('opendroid-theme') || 'dark');</script>
+
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Security — OpenDroid</title>
@@ -27,6 +29,13 @@
       <span></span><span></span><span></span>
     </button>
     <ul class="nav-links" id="nav-links">
+      <li class="theme-toggle-item">
+        <button class="theme-toggle" id="theme-toggle" type="button" aria-label="Activer le mode clair" aria-pressed="false">
+          <svg class="icon-sun" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"></circle><line x1="12" y1="1" x2="12" y2="3"></line><line x1="12" y1="21" x2="12" y2="23"></line><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line><line x1="1" y1="12" x2="3" y2="12"></line><line x1="21" y1="12" x2="23" y2="12"></line><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line></svg>
+          <svg class="icon-moon" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path></svg>
+        </button>
+      </li>
+
       <li class="nav-dropdown">
         <a href="features.html">Products</a>
         <ul class="dropdown-menu">

--- a/website/security.html
+++ b/website/security.html
@@ -25,17 +25,8 @@
       <img src="assets/bot.png" alt="OpenDroid">
       <span>OpenDroid</span>
     </a>
-    <button class="nav-hamburger" id="nav-hamburger" aria-label="Toggle menu">
-      <span></span><span></span><span></span>
-    </button>
+    <div class="nav-right">
     <ul class="nav-links" id="nav-links">
-      <li class="theme-toggle-item">
-        <button class="theme-toggle" id="theme-toggle" type="button" aria-label="Activer le mode clair" aria-pressed="false">
-          <svg class="icon-sun" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"></circle><line x1="12" y1="1" x2="12" y2="3"></line><line x1="12" y1="21" x2="12" y2="23"></line><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line><line x1="1" y1="12" x2="3" y2="12"></line><line x1="21" y1="12" x2="23" y2="12"></line><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line></svg>
-          <svg class="icon-moon" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path></svg>
-        </button>
-      </li>
-
       <li class="nav-dropdown">
         <a href="features.html">Products</a>
         <ul class="dropdown-menu">
@@ -70,6 +61,16 @@
         <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align: middle; margin-left: 4px;"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path><polyline points="7 10 12 15 17 10"></polyline><line x1="12" y1="15" x2="12" y2="3"></line></svg>
       </a></li>
     </ul>
+    <div class="nav-controls">
+      <button class="theme-toggle" id="theme-toggle" type="button" aria-label="Enable light mode" aria-pressed="false">
+        <svg class="icon-sun" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"></circle><line x1="12" y1="1" x2="12" y2="3"></line><line x1="12" y1="21" x2="12" y2="23"></line><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line><line x1="1" y1="12" x2="3" y2="12"></line><line x1="21" y1="12" x2="23" y2="12"></line><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line></svg>
+        <svg class="icon-moon" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path></svg>
+        <span class="theme-toggle-text-wrap"><span class="tt-dark">Dark</span><span class="tt-light">Light</span></span>
+      </button>
+      <button class="nav-hamburger" id="nav-hamburger" aria-label="Toggle menu">
+        <span></span><span></span><span></span>
+      </button>
+    </div>
   </div>
 </nav>
 

--- a/website/support.html
+++ b/website/support.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <script>document.documentElement.setAttribute('data-theme', localStorage.getItem('opendroid-theme') || 'dark');</script>
+
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Support — OpenDroid</title>
@@ -27,6 +29,13 @@
       <span></span><span></span><span></span>
     </button>
     <ul class="nav-links" id="nav-links">
+      <li class="theme-toggle-item">
+        <button class="theme-toggle" id="theme-toggle" type="button" aria-label="Activer le mode clair" aria-pressed="false">
+          <svg class="icon-sun" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"></circle><line x1="12" y1="1" x2="12" y2="3"></line><line x1="12" y1="21" x2="12" y2="23"></line><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line><line x1="1" y1="12" x2="3" y2="12"></line><line x1="21" y1="12" x2="23" y2="12"></line><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line></svg>
+          <svg class="icon-moon" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path></svg>
+        </button>
+      </li>
+
       <li class="nav-dropdown">
         <a href="features.html">Products</a>
         <ul class="dropdown-menu">

--- a/website/support.html
+++ b/website/support.html
@@ -25,17 +25,8 @@
       <img src="assets/bot.png" alt="OpenDroid">
       <span>OpenDroid</span>
     </a>
-    <button class="nav-hamburger" id="nav-hamburger" aria-label="Toggle menu">
-      <span></span><span></span><span></span>
-    </button>
+    <div class="nav-right">
     <ul class="nav-links" id="nav-links">
-      <li class="theme-toggle-item">
-        <button class="theme-toggle" id="theme-toggle" type="button" aria-label="Activer le mode clair" aria-pressed="false">
-          <svg class="icon-sun" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"></circle><line x1="12" y1="1" x2="12" y2="3"></line><line x1="12" y1="21" x2="12" y2="23"></line><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line><line x1="1" y1="12" x2="3" y2="12"></line><line x1="21" y1="12" x2="23" y2="12"></line><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line></svg>
-          <svg class="icon-moon" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path></svg>
-        </button>
-      </li>
-
       <li class="nav-dropdown">
         <a href="features.html">Products</a>
         <ul class="dropdown-menu">
@@ -71,6 +62,16 @@
         <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align: middle; margin-left: 4px;"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path><polyline points="7 10 12 15 17 10"></polyline><line x1="12" y1="15" x2="12" y2="3"></line></svg>
       </a></li>
     </ul>
+    <div class="nav-controls">
+      <button class="theme-toggle" id="theme-toggle" type="button" aria-label="Enable light mode" aria-pressed="false">
+        <svg class="icon-sun" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"></circle><line x1="12" y1="1" x2="12" y2="3"></line><line x1="12" y1="21" x2="12" y2="23"></line><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line><line x1="1" y1="12" x2="3" y2="12"></line><line x1="21" y1="12" x2="23" y2="12"></line><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line></svg>
+        <svg class="icon-moon" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path></svg>
+        <span class="theme-toggle-text-wrap"><span class="tt-dark">Dark</span><span class="tt-light">Light</span></span>
+      </button>
+      <button class="nav-hamburger" id="nav-hamburger" aria-label="Toggle menu">
+        <span></span><span></span><span></span>
+      </button>
+    </div>
   </div>
 </nav>
 

--- a/website/terms.html
+++ b/website/terms.html
@@ -25,17 +25,8 @@
       <img src="assets/bot.png" alt="OpenDroid">
       <span>OpenDroid</span>
     </a>
-    <button class="nav-hamburger" id="nav-hamburger" aria-label="Toggle menu">
-      <span></span><span></span><span></span>
-    </button>
+    <div class="nav-right">
     <ul class="nav-links" id="nav-links">
-      <li class="theme-toggle-item">
-        <button class="theme-toggle" id="theme-toggle" type="button" aria-label="Activer le mode clair" aria-pressed="false">
-          <svg class="icon-sun" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"></circle><line x1="12" y1="1" x2="12" y2="3"></line><line x1="12" y1="21" x2="12" y2="23"></line><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line><line x1="1" y1="12" x2="3" y2="12"></line><line x1="21" y1="12" x2="23" y2="12"></line><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line></svg>
-          <svg class="icon-moon" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path></svg>
-        </button>
-      </li>
-
       <li class="nav-dropdown">
         <a href="features.html">Products</a>
         <ul class="dropdown-menu">
@@ -70,6 +61,16 @@
         <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align: middle; margin-left: 4px;"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path><polyline points="7 10 12 15 17 10"></polyline><line x1="12" y1="15" x2="12" y2="3"></line></svg>
       </a></li>
     </ul>
+    <div class="nav-controls">
+      <button class="theme-toggle" id="theme-toggle" type="button" aria-label="Enable light mode" aria-pressed="false">
+        <svg class="icon-sun" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"></circle><line x1="12" y1="1" x2="12" y2="3"></line><line x1="12" y1="21" x2="12" y2="23"></line><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line><line x1="1" y1="12" x2="3" y2="12"></line><line x1="21" y1="12" x2="23" y2="12"></line><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line></svg>
+        <svg class="icon-moon" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path></svg>
+        <span class="theme-toggle-text-wrap"><span class="tt-dark">Dark</span><span class="tt-light">Light</span></span>
+      </button>
+      <button class="nav-hamburger" id="nav-hamburger" aria-label="Toggle menu">
+        <span></span><span></span><span></span>
+      </button>
+    </div>
   </div>
 </nav>
 

--- a/website/terms.html
+++ b/website/terms.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <script>document.documentElement.setAttribute('data-theme', localStorage.getItem('opendroid-theme') || 'dark');</script>
+
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Terms of Service — OpenDroid</title>
@@ -27,6 +29,13 @@
       <span></span><span></span><span></span>
     </button>
     <ul class="nav-links" id="nav-links">
+      <li class="theme-toggle-item">
+        <button class="theme-toggle" id="theme-toggle" type="button" aria-label="Activer le mode clair" aria-pressed="false">
+          <svg class="icon-sun" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"></circle><line x1="12" y1="1" x2="12" y2="3"></line><line x1="12" y1="21" x2="12" y2="23"></line><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line><line x1="1" y1="12" x2="3" y2="12"></line><line x1="21" y1="12" x2="23" y2="12"></line><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line></svg>
+          <svg class="icon-moon" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path></svg>
+        </button>
+      </li>
+
       <li class="nav-dropdown">
         <a href="features.html">Products</a>
         <ul class="dropdown-menu">


### PR DESCRIPTION
## Summary

Two things bundled together — flagging that split clearly since they're different in nature:

### 1. Bug fixes (safe, uncontroversial)
- `contributor.html` had a page-specific `<style>` block (235 lines) duplicating colors that ignored dark/light state entirely (hardcoded `#3b82f6` blue, `#fef3c7` amber badges). Migrated into `style.css` as single source of truth.
- `.divider` (used between Contributors/Testers sections) had no matching CSS rule anywhere — rendered as nothing.
- `features.html`'s nav Download button was missing the icon + `aria-label` present on the other 7 pages.
- Theme toggle aria-labels were in French on an all-English site.
- `--text-muted` used an identical hex in both themes, undershooting WCAG AA against `--bg-secondary` (4.34:1 dark / 3.75:1 light) — split into two theme-appropriate values (6.02:1 / 5.41:1, verified against actual rendered colors).
- Navbar scroll shadow was set via inline JS style with a hardcoded light-mode-only rgba — now a class + theme-aware CSS variable.
- Removed dead code: unused `@keyframes float`, and a `#particles-canvas` element with no JS ever targeting it.

### 2. Light/dark mode + visual redesign (more subjective — happy to adjust or drop if it's not the direction you want)
- Added a light/dark toggle, persisted via `localStorage`, no-FOUC inline script.
- Toggle lives in a persistent `nav-controls` cluster outside the collapsible mobile menu — reachable in one tap on every page/viewport instead of buried in the hamburger panel.
- Mobile menu rebuilt from a 280px translucent sidebar into a full-screen panel with larger tap targets.
- New type pairing (IBM Plex Mono + IBM Plex Sans), tighter radius scale, two-tone green palette instead of a single accent on near-black, bracket-framed buttons (`[ Download APK ]`) tied to the product being a command/agent tool.
- Removed the gradient-text hero effect and the pulsing gradient-blob behind the video.

## Testing
- No horizontal overflow on any of the 8 pages at 390px, either theme (checked programmatically, not eyeballed)
- Theme toggle confirmed in-viewport/reachable on all 8 pages × both themes without opening the mobile menu
- Contrast ratios computed against actual rendered colors post-build
- FAQ accordion + nav dropdowns functional, zero console errors across all pages/themes
- `build.sh` output unchanged in structure
- Rebased on current `main` (was 37 commits behind) — no conflicts, your Product Hunt links / new security & terms content came through clean

Live preview on my fork while this is open: https://sudomarc.github.io/opendroid/

If you'd rather merge just the bug-fix half and pass on the redesign, say so and I'll split it — didn't want to open two PRs before knowing which direction you'd want.
