### PR TITLE
fix: prevent keyboard from covering chat input (IME insets)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -80,6 +80,7 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
+            android:windowSoftInputMode="adjustResize"
             android:theme="@android:style/Theme.DeviceDefault.NoActionBar">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />


### PR DESCRIPTION
## Description
Fixes the chat UI breaking when the on-screen keyboard pops up — the keyboard covers the input field and the send button.

**Root cause:** `MainActivity` declares no `android:windowSoftInputMode`, so the system default (`adjustUnspecified`) behaves like `adjustPan` on many devices, notably **vivo/iQOO Funtouch OS**. With edge-to-edge enabled, the IME insets are never delivered to the Compose UI, so `Modifier.imePadding()` in `ChatScreen.kt` (line 355) computes 0 and the keyboard slides over the input bar instead of pushing it up.

**Fix:** declare `android:windowSoftInputMode=\"adjustResize\"` on `MainActivity` so the window resizes for the IME and the input bar + message list stay above the keyboard.

Fixes # (no issue filed; discovered during manual testing of v1.0.3)

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
- **Test Configuration**: Android 16 / physical device (vivo iQOO I2221, Funtouch OS) — the device that exhibited the bug.
- **Manual Verification steps**:
  1. Reproduced on v1.0.3 release APK: keyboard covered chat input + send button
  2. Applied `windowSoftInputMode=\"adjustResize\"` to MainActivity
  3. Input bar now fully visible above the keyboard; message list scrolls correctly
  4. No regression on other screens (flag is per-activity, affects only MainActivity)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas (N/A — one-line manifest attribute)
- [x] My changes generate no new build errors or warnings
- [x] I have updated the documentation in the `docs/` folder (if applicable — N/A)
