### PR TITLE
fix: add gemini-2.5-flash to Gemini provider model list

### DIFF
--- a/app/src/main/java/com/opendroid/ai/core/llm/ModelFetcher.kt
+++ b/app/src/main/java/com/opendroid/ai/core/llm/ModelFetcher.kt
@@ -488,7 +488,7 @@ class ModelFetcher @Inject constructor(
 
     private fun getGeminiFallback() = listOf(
         AIModel("gemini-2.5-flash", "Gemini 2.5 Flash", "Google Gemini", isRecommended = true, isFree = true),
-        AIModel("gemini-2.0-flash", "Gemini 2.0 Flash", "Google Gemini", isRecommended = true, isFree = true),
+        AIModel("gemini-2.0-flash", "Gemini 2.0 Flash", "Google Gemini", isFree = true),
         AIModel("gemini-1.5-pro", "Gemini 1.5 Pro", "Google Gemini", isPremium = true),
         AIModel("gemini-1.5-flash", "Gemini 1.5 Flash", "Google Gemini", isFree = true),
         AIModel("gemini-nano", "Gemini Nano (On-device Mock)", "Google Gemini")

--- a/app/src/main/java/com/opendroid/ai/core/llm/ModelFetcher.kt
+++ b/app/src/main/java/com/opendroid/ai/core/llm/ModelFetcher.kt
@@ -487,6 +487,7 @@ class ModelFetcher @Inject constructor(
     )
 
     private fun getGeminiFallback() = listOf(
+        AIModel("gemini-2.5-flash", "Gemini 2.5 Flash", "Google Gemini", isRecommended = true, isFree = true),
         AIModel("gemini-2.0-flash", "Gemini 2.0 Flash", "Google Gemini", isRecommended = true, isFree = true),
         AIModel("gemini-1.5-pro", "Gemini 1.5 Pro", "Google Gemini", isPremium = true),
         AIModel("gemini-1.5-flash", "Gemini 1.5 Flash", "Google Gemini", isFree = true),

--- a/app/src/main/java/com/opendroid/ai/core/llm/providers/GeminiProvider.kt
+++ b/app/src/main/java/com/opendroid/ai/core/llm/providers/GeminiProvider.kt
@@ -26,7 +26,7 @@ class GeminiProvider @Inject constructor(
 ) : LLMProvider {
 
     override val name: String = "Google Gemini"
-    override val availableModels: List<String> = listOf("gemini-2.0-flash", "gemini-1.5-pro", "gemini-nano")
+    override val availableModels: List<String> = listOf("gemini-2.5-flash", "gemini-2.0-flash", "gemini-1.5-pro", "gemini-nano")
 
     private val gson = Gson()
     private val mediaType = "application/json; charset=utf-8".toMediaType()


### PR DESCRIPTION
## Description
The Gemini provider's model list and the Settings picker's cached model list are both stale — none of the offered models work reliably on free-tier API keys:

- `gemini-2.0-flash` — frequently returns `429 RESOURCE_EXHAUSTED` (quota exceeded) on free-tier keys
- `gemini-1.5-pro` — **retired** by Google (returns `404 NOT_FOUND`)
- `gemini-nano` — on-device mock, not a real API model
- `gemini-2.5-flash` — current recommended model, works with free-tier keys, but **missing from both lists**

**Fix (2 files):**

1. `GeminiProvider.kt` — `availableModels`:
```kotlin
- listOf("gemini-2.0-flash", "gemini-1.5-pro", "gemini-nano")
+ listOf("gemini-2.5-flash", "gemini-2.0-flash", "gemini-1.5-pro", "gemini-nano")
```

2. `ModelFetcher.kt` — `getGeminiFallback()` (this is what the Settings model picker actually displays; the provider never hits the live Gemini /models API, so the provider list alone is not sufficient):
```kotlin
+ AIModel("gemini-2.5-flash", "Gemini 2.5 Flash", "Google Gemini", isRecommended = true, isFree = true),
  AIModel("gemini-2.0-flash", "Gemini 2.0 Flash", "Google Gemini", isRecommended = true, isFree = true),
```

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
- **Test Configuration**: Google Gemini REST API (v1beta), free-tier API key; vivo iQOO I2221 (Android 16).
- **Manual Verification steps**:
  1. Same free-tier key: `gemini-2.0-flash` → 429 RESOURCE_EXHAUSTED, `gemini-1.5-pro` → 404 NOT_FOUND
  2. `gemini-2.5-flash` → 200 OK, valid `generateContent` response (verified 3x)
  3. APK built locally with both changes, installed: tap refresh in Settings → ACTIVE MODEL row → `Gemini 2.5 Flash` appears in picker (cache is refreshed from the new fallback list)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas (N/A — small list changes)
- [x] My changes generate no new build errors or warnings
- [x] I have updated the documentation in the `docs/` folder (if applicable — N/A)
