### PR TITLE
fix: stop AndroidGradlePluginVersion lint check from gating CI

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -160,6 +160,11 @@ android {
         baseline = file("lint-baseline.xml")
         error 'Recycle', 'UnusedResources', 'IconDuplicates', 'UseKtx', 'DefaultLocale',
                 'DuplicateUsesFeature', 'InlinedApi', 'AutoboxingStateCreation'
+        // Fires whenever a newer Gradle/AGP is published, so under
+        // warningsAsErrors it breaks every branch the day of a release
+        // (e.g. Gradle 9.7.0 broke CI repo-wide). Version bumps are deliberate
+        // upgrades, not lint findings - keep the hint visible but never gating.
+        informational 'AndroidGradlePluginVersion'
     }
 }
 


### PR DESCRIPTION
## Description
CI went red on every open PR (#32, #33) with no change on their side:

```
gradle/wrapper/gradle-wrapper.properties:4: Error: A newer version of Gradle than 9.6.1 is available: 9.7.0 [AndroidGradlePluginVersion]
```

The `AndroidGradlePluginVersion` lint check fires whenever a newer Gradle/AGP version is published. Under `warningsAsErrors true` that means every Gradle release instantly breaks all branches — a time-bomb unrelated to any code change.

**Fix:** demote the check to `informational` in the lint block. The hint stays visible in lint reports, but version availability never fails the build. Gradle/AGP bumps remain deliberate upgrades.

Bumping the wrapper to 9.7.0 instead would fix today and break again next release, so this addresses the class of failure.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- No local JDK available; verified via CI on this PR — the Android Lint job on this branch runs the exact failing check against wrapper 9.6.1 and must pass with this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)